### PR TITLE
Fix Alert Icon Size Prop error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,4 +81,4 @@ RUN aws s3 cp s3://admin-ui-docs.commerce7.com/index.html s3://admin-ui-docs.com
 
 # Run NPM Publish
 RUN npm run build
-RUN npm run publish
+RUN npm publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.7.43",
+  "version": "1.7.44",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/alert/Alert.js
+++ b/src/alert/Alert.js
@@ -4,7 +4,6 @@ import { StyledAlert, StyledIcon } from './Alert.styles';
 
 const Alert = (props) => {
   const { variant, icon, size, children, className, dataTestId } = props;
-
   return (
     <StyledAlert
       className={className}
@@ -12,7 +11,7 @@ const Alert = (props) => {
       data-testid={dataTestId}
       size={size}
     >
-      <StyledIcon icon={icon} variant={variant} size={size} />
+      <StyledIcon icon={icon} variant={variant} alertSize={size} />
       {children}
     </StyledAlert>
   );

--- a/src/alert/Alert.styles.js
+++ b/src/alert/Alert.styles.js
@@ -34,10 +34,10 @@ const StyledAlert = styled.div`
 
 const StyledIcon = styled(Icon)`
   transform: translateY(2px);
-  margin-right: ${({ size }) => sizes[size].iconMargin};
+  margin-right: ${({ alertSize }) => sizes[alertSize].iconMargin};
 
-  width: ${({ size }) => sizes[size].iconSize};
-  min-width: ${({ size }) => sizes[size].iconSize};
+  width: ${({ alertSize }) => sizes[alertSize].iconSize};
+  min-width: ${({ alertSize }) => sizes[alertSize].iconSize};
   height: auto;
   min-height: auto;
 

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,12 @@
 
 # Release Notes
 
+#### 1.7.44
+
+- Fixed `Alert` icon prop type error
+
+---
+
 #### 1.7.43
 
 - Added `Alert` component


### PR DESCRIPTION
@tlouth19 I was passing size into the StyledIcon which was throwing this error since the Icon component itself had a size prop that wasn't matching the small Alert prop types.

![Screen Shot 2021-12-13 at 11 57 24 AM](https://user-images.githubusercontent.com/64668108/145879790-9cedabdf-f3ca-4a62-9ac4-d34e65a26b54.png)
