### PR TITLE
Added calendar icon to datepicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.7.44",
+  "version": "1.7.45",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/datePicker/DatePicker.js
+++ b/src/datePicker/DatePicker.js
@@ -11,7 +11,11 @@ import {
   StyledDescription
 } from '../common/form/styles';
 import { getFormItemIds } from '../common/form/helpers';
-import { StyledInput } from '../input/Input.styles';
+import {
+  StyledInput,
+  StyledIconWrapper,
+  StyledInputIcon
+} from '../input/Input.styles';
 import { StyledDatePicker, StyledClearButton } from './DatePicker.styles';
 
 const DatePicker = forwardRef((props, ref) => {
@@ -77,23 +81,27 @@ const DatePicker = forwardRef((props, ref) => {
           utc
           closeOnSelect
           renderInput={(componentProps) => (
-            <StyledInput
-              aria-describedby={describedById}
-              aria-labelledby={labelId}
-              aria-invalid={hasErrorMessage}
-              aria-required={required}
-              ref={ref}
-              disabled={disabled}
-              placeholder={placeholder}
-              id={id}
-              value={value}
-              onBlur={onBlur}
-              onChange={onChange}
-              onFocus={onFocus}
-              hasErrorMessage={hasErrorMessage}
-              readOnly
-              {...componentProps} // eslint-disable-line
-            />
+            <StyledIconWrapper>
+              <StyledInputIcon icon="reservation" iconPosition="start" />
+              <StyledInput
+                aria-describedby={describedById}
+                aria-labelledby={labelId}
+                aria-invalid={hasErrorMessage}
+                aria-required={required}
+                ref={ref}
+                disabled={disabled}
+                placeholder={placeholder}
+                id={id}
+                value={value}
+                onBlur={onBlur}
+                onChange={onChange}
+                onFocus={onFocus}
+                hasErrorMessage={hasErrorMessage}
+                readOnly
+                startIcon="reservation"
+                {...componentProps} // eslint-disable-line
+              />
+            </StyledIconWrapper>
           )}
         />
         {allowClear && value && (

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,12 @@
 
 # Release Notes
 
+#### 1.7.45
+
+- Added calendar icon to `DatePicker`
+
+---
+
 #### 1.7.44
 
 - Fixed `Alert` icon prop type error


### PR DESCRIPTION
@JakeHildy this updates the `DatePicker` component to show a calendar icon always

Blocked by #6 (waiting on the NPM publish fix before merging that PR)

![Screen Shot 2021-12-14 at 8 47 37 AM](https://user-images.githubusercontent.com/12659802/146010792-e718de56-3b4b-4ebb-8f0b-ec69a6a8ad37.png)
