### PR TITLE
Added icon to avatar when no image or label is provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.7.50",
+  "version": "1.7.51",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/avatar/Avatar.js
+++ b/src/avatar/Avatar.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 
-import { StyledAvatar } from './Avatar.styles';
+import { StyledAvatar, StyledAvatarIcon } from './Avatar.styles';
 
 const Avatar = (props) => {
   const [isImageValid, setImageValid] = useState(true);
@@ -17,6 +17,10 @@ const Avatar = (props) => {
     content = <img src={imageSrc} alt={imageAlt} onError={handleImageError} />;
   }
 
+  if (!content) {
+    content = <StyledAvatarIcon avatarSize={size} icon="user" />;
+  }
+
   return (
     <StyledAvatar className={className} size={size} data-testid={dataTestId}>
       {content}
@@ -28,13 +32,14 @@ Avatar.defaultProps = {
   className: null,
   imageSrc: null,
   imageAlt: '',
+  label: '',
   size: 'default',
   dataTestId: null
 };
 
 Avatar.propTypes = {
   className: PropTypes.string,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
   imageSrc: PropTypes.string,
   imageAlt: PropTypes.string,
   size: PropTypes.oneOf(['small', 'default', 'large', 'tiny']),

--- a/src/avatar/Avatar.styles.js
+++ b/src/avatar/Avatar.styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
-import { sizes, fontSizes, colors } from './theme';
+import Icon from '../icon';
+import { sizes, iconSizes, fontSizes, colors } from './theme';
 
 const StyledAvatar = styled.div`
   font-weight: ${({ theme }) => theme.c7__ui.fontWeightBase};
@@ -34,4 +35,18 @@ const StyledAvatar = styled.div`
   }
 `;
 
-export { StyledAvatar };
+const StyledAvatarIcon = styled(Icon)`
+  background-color: transparent;
+  ${({ avatarSize }) => `
+    width: ${iconSizes[avatarSize]};
+    min-width: ${iconSizes[avatarSize]};
+    height: ${iconSizes[avatarSize]};
+    min-height: ${iconSizes[avatarSize]};
+    fill: ${({ theme }) => colors[theme.c7__ui.mode].iconColor};
+  `}
+  path {
+    fill: ${({ theme }) => colors[theme.c7__ui.mode].iconColor};
+  }
+`;
+
+export { StyledAvatar, StyledAvatarIcon };

--- a/src/avatar/theme.js
+++ b/src/avatar/theme.js
@@ -12,15 +12,24 @@ const fontSizes = {
   large: '42px'
 };
 
+const iconSizes = {
+  tiny: '13px',
+  small: '18px',
+  default: '22px',
+  large: '42px'
+};
+
 const colors = {
   light: {
     background: '#D1D1D1',
-    fontColor: '#0192D0'
+    fontColor: '#0192D0',
+    iconColor: '#0192d0'
   },
   dark: {
     background: '#585E64',
-    fontColor: '#3FB2EE'
+    fontColor: '#3FB2EE',
+    iconColor: '#0192d0'
   }
 };
 
-export { sizes, fontSizes, colors };
+export { sizes, iconSizes, fontSizes, colors };

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,12 @@
 
 # Release Notes
 
+#### 1.7.51
+
+- Added fallback icon to `Avatar` when no label or image is provided
+
+---
+
 #### 1.7.50
 
 - Added `inputMode` prop to `Input`


### PR DESCRIPTION
@andrewkamphuis the avatar will now show a user icon instead of just am empty circle if there is no initials or profile image 
![Screen Shot 2022-01-07 at 8 45 51 AM](https://user-images.githubusercontent.com/12659802/148552847-2990017a-7fc0-4e44-9b77-13373bc6251e.png)
