### PR TITLE
Add DisplayIcon to AdminUI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.7.62",
+  "version": "1.7.63",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/displayIcon/DisplayIcon.js
+++ b/src/displayIcon/DisplayIcon.js
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types';
-import * as Icons from './icons';
-import { StyledIcon, StyledIconButton } from './Icon.styles';
+import * as Icons from '../icon/icons';
 
+import { StyledIcon } from './DisplayIcon.styles';
+import { StyledIconButton } from '../icon/Icon.styles';
 import IconWrapper from './IconWrapper';
 
-const Icon = (props) => {
-  const { className, icon, label, onClick, size, variant, dataTestId } = props;
+const DisplayIcon = (props) => {
+  const { className, icon, label, onClick, variant, dataTestId } = props;
 
   const IconComponent = Icons[icon];
 
@@ -20,12 +21,11 @@ const Icon = (props) => {
         title={label}
         data-testid={dataTestId}
       >
-        <IconWrapper size={size}>
+        <IconWrapper>
           <StyledIcon
             as={IconComponent}
             variant={variant}
             className={className}
-            size={size}
           />
         </IconWrapper>
       </StyledIconButton>
@@ -33,29 +33,26 @@ const Icon = (props) => {
   }
 
   return (
-    <IconWrapper size={size} dataTestId={dataTestId}>
+    <IconWrapper dataTestId={dataTestId}>
       <StyledIcon
         as={IconComponent}
         variant={variant}
         className={className}
-        dataTestId={dataTestId}
         aria-label={label}
-        size={size}
       />
     </IconWrapper>
   );
 };
 
-Icon.defaultProps = {
+DisplayIcon.defaultProps = {
   className: null,
   label: null,
   onClick: null,
-  size: 'default',
   variant: 'default',
   dataTestId: null
 };
 
-Icon.propTypes = {
+DisplayIcon.propTypes = {
   /**
    * Add className to the outermost element.
    */
@@ -78,11 +75,6 @@ Icon.propTypes = {
   onClick: PropTypes.func,
 
   /**
-   * Set the size of the icon.
-   */
-  size: PropTypes.oneOf(['default', 'large']),
-
-  /**
    * Set the visual property of the component.
    */
   variant: PropTypes.oneOf(['default', 'success', 'error']),
@@ -93,4 +85,4 @@ Icon.propTypes = {
   dataTestId: PropTypes.string
 };
 
-export default Icon;
+export default DisplayIcon;

--- a/src/displayIcon/DisplayIcon.stories.js
+++ b/src/displayIcon/DisplayIcon.stories.js
@@ -1,0 +1,49 @@
+import { action } from '@storybook/addon-actions';
+import DisplayIcon from './DisplayIcon';
+
+export const basic = () => (
+  <>
+    <DisplayIcon icon="cart" />
+  </>
+);
+
+basic.story = {
+  name: 'Basic'
+};
+
+export const variants = () => (
+  <>
+    <DisplayIcon icon="cart" variant="default" />
+    <DisplayIcon icon="cart" variant="success" />
+    <DisplayIcon icon="cart" variant="error" />
+  </>
+);
+
+variants.story = {
+  name: 'Variants'
+};
+
+export const onClick = () => (
+  <DisplayIcon
+    icon="add"
+    onClick={action('on-click')}
+    label="Add to cart"
+    dataTestId="testing"
+  />
+);
+
+onClick.story = {
+  name: 'Click'
+};
+
+export default {
+  title: 'Icon/DisplayIcon',
+  component: DisplayIcon,
+  parameters: {
+    docs: {
+      description: {
+        component: "import { DisplayIcon } from '@commerce7/admin-ui'"
+      }
+    }
+  }
+};

--- a/src/displayIcon/DisplayIcon.stories.js
+++ b/src/displayIcon/DisplayIcon.stories.js
@@ -24,12 +24,7 @@ variants.story = {
 };
 
 export const onClick = () => (
-  <DisplayIcon
-    icon="add"
-    onClick={action('on-click')}
-    label="Add to cart"
-    dataTestId="testing"
-  />
+  <DisplayIcon icon="add" onClick={action('on-click')} label="Add to cart" />
 );
 
 onClick.story = {

--- a/src/displayIcon/DisplayIcon.styles.js
+++ b/src/displayIcon/DisplayIcon.styles.js
@@ -3,7 +3,6 @@ import { StyledIcon as UIStyledIcon } from '../icon/Icon.styles';
 import { backgroundColors } from '../icon/theme';
 
 const StyledIcon = styled(UIStyledIcon)`
-  display: inline-block;
   width: 28px;
   height: 28px;
   min-width: 28px;

--- a/src/displayIcon/DisplayIcon.styles.js
+++ b/src/displayIcon/DisplayIcon.styles.js
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+import { StyledIcon as UIStyledIcon } from '../icon/Icon.styles';
+import { backgroundColors } from '../icon/theme';
+
+const StyledIcon = styled(UIStyledIcon)`
+  display: inline-block;
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  min-height: 28px;
+`;
+
+const StyledDisplayIcon = styled.div`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: ${({ theme }) => backgroundColors[theme.c7__ui.mode]};
+  border-radius: 50%;
+  height: 70px;
+  width: 70px;
+`;
+
+export { StyledDisplayIcon, StyledIcon };

--- a/src/displayIcon/IconWrapper.js
+++ b/src/displayIcon/IconWrapper.js
@@ -1,0 +1,10 @@
+import { StyledDisplayIcon } from './DisplayIcon.styles';
+
+const IconWrapper = (props) => {
+  const { children, dataTestId } = props;
+  return (
+    <StyledDisplayIcon data-testid={dataTestId}>{children}</StyledDisplayIcon>
+  );
+};
+
+export default IconWrapper;

--- a/src/displayIcon/index.js
+++ b/src/displayIcon/index.js
@@ -1,0 +1,3 @@
+import DisplayIcon from './DisplayIcon';
+
+export default DisplayIcon;

--- a/src/icon/Icon.stories.js
+++ b/src/icon/Icon.stories.js
@@ -96,7 +96,7 @@ List.story = {
 };
 
 export default {
-  title: 'UI/Icon',
+  title: 'Icon/Icon',
   component: Icon,
   parameters: {
     docs: {

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ import ButtonMenu from './buttonMenu';
 // UI
 import Avatar from './avatar';
 import Alert from './alert';
-import Icon from './icon';
 import Message from './message';
 import Modal from './modal';
 import Tag from './tag';
@@ -34,6 +33,10 @@ import Select from './select';
 import Switch from './switch';
 import Textarea from './textarea';
 
+// Icon
+import Icon from './icon';
+import DisplayIcon from './displayIcon';
+
 // Typography
 import Heading from './heading';
 import Text from './text';
@@ -52,6 +55,7 @@ export {
   DatePicker,
   Heading,
   Icon,
+  DisplayIcon,
   Input,
   LineBreak,
   LinkButton,

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,12 @@
 
 # Release Notes
 
+#### 1.7.63
+
+- Add `DisplayIcon` component. This is the same as the `Icon` `size="large"` component which will be removed in a future update.
+
+---
+
 #### 1.7.62
 
 - Added className prop to inline `DatePicker`


### PR DESCRIPTION
@tlouth19 this adds the DisplayIcon to admin UI like we discussed. I extended some of the styling and theme from Icon but defined new styles that are related to the size so we can remove that from Icon in the future.