### PR TITLE
Added link color to c7 theme object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/button/theme.js
+++ b/src/button/theme.js
@@ -73,10 +73,10 @@ const colors = {
     },
     link: {
       fontColor: {
-        default: 'rgb(1, 146, 208)',
-        hover: 'rgb(1, 146, 208)',
-        focus: 'rgb(1, 146, 208)',
-        disabled: 'rgb(175, 175, 175)'
+        default: 'rgb(80, 164, 252)',
+        hover: 'rgb(80, 164, 252)',
+        focus: 'rgb(80, 164, 252)',
+        disabled: 'rgb(80, 164, 252)'
       },
       backgroundColor: {
         default: 'transparent',

--- a/src/button/theme.js
+++ b/src/button/theme.js
@@ -76,7 +76,7 @@ const colors = {
         default: 'rgb(80, 164, 252)',
         hover: 'rgb(80, 164, 252)',
         focus: 'rgb(80, 164, 252)',
-        disabled: 'rgb(80, 164, 252)'
+        disabled: 'rgb(175, 175, 175)'
       },
       backgroundColor: {
         default: 'transparent',

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,12 @@
 
 # Release Notes
 
+#### 1.8.8
+
+- Updated dark mode link and button font colors
+
+---
+
 #### 1.8.7
 
 - Updated NPM packages

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -30,6 +30,11 @@ const boxShadow = {
   dark: '2px 4px 6px rgba(0,0,0,0.5)'
 };
 
+const linkColors = {
+  light: 'rgb(0, 103, 157)',
+  dark: 'rgb(80, 164, 252)'
+};
+
 export const createTheme = (mode) => ({
   c7__ui: {
     mode,
@@ -40,6 +45,7 @@ export const createTheme = (mode) => ({
     fontWeightStrong: '600',
     fontColor: fontColors[mode],
     secondaryFontColor: secondaryFontColors[mode],
+    linkColor: linkColors[mode],
     backgroundColor: backgroundColors[mode],
     secondaryBackgroundColor: secondaryBackgroundColors[mode],
     borderColor: borderColors[mode],

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -75,4 +75,8 @@ export const GlobalStyles = createGlobalStyle`
     font-weight:  ${({ theme }) => theme.c7__ui.fontWeightBase};
     background-color: ${({ theme }) => theme.c7__ui.backgroundColor}; 
   }
+  a {
+    color: ${({ theme }) => theme.c7__ui.linkColor};
+    text-decoration: none;
+  }
 `;


### PR DESCRIPTION
@JakeHildy the links in dark mode are hard to read right now inside admin. This adds a `linkColor` to the theme object, so we can use it in admin. 

Also updated the LinkButton to use this new colour in dark mode.