### PR TITLE
Remove type on breadcrumbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/breadcrumbs/Breadcrumb.js
+++ b/src/breadcrumbs/Breadcrumb.js
@@ -9,16 +9,16 @@ const Breadcrumb = (props) => {
     props;
 
   let as = '';
-  let type = '';
-
   if (href) {
     as = 'a';
   } else if (!href && onClick) {
     as = 'button';
-    type = 'button';
   }
 
   let customComponentProps = {};
+  if (as === 'button') {
+    customComponentProps.type = 'button';
+  }
   if (component) {
     as = component;
     customComponentProps = { ...rest };
@@ -30,7 +30,6 @@ const Breadcrumb = (props) => {
         as={as}
         onClick={onClick}
         href={href}
-        type={type}
         {...customComponentProps} // eslint-disable-line
       >
         <Text>{children}</Text>

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,12 @@
 
 # Release Notes
 
+#### 1.8.9
+
+- Updated `Breadcrumbs` component.
+
+---
+
 #### 1.8.8
 
 - Updated dark mode link and button font colors


### PR DESCRIPTION
@tlouth19 this removes the extra `type` on breadcrumbs that end up as anchor tags