### PR TITLE
Sc 1610 button menu bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.8.12",
+  "version": "1.8.13",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/buttonMenu/ButtonMenu.js
+++ b/src/buttonMenu/ButtonMenu.js
@@ -47,11 +47,7 @@ const ButtonMenu = (props) => {
         disabled={disabled}
       >
         {label}
-        <StyledButtonIcon
-          icon="chevronDown"
-          buttonVariant={variant}
-          size="default"
-        />
+        <StyledButtonIcon icon="chevronDown" buttonVariant={variant} />
       </StyledButton>
       <DropdownMenu
         isVisible={isDropdownVisible}

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,12 @@
 
 # Release Notes
 
+#### 1.8.13
+
+- Fixed `ButtonMenu` warning.
+
+---
+
 #### 1.8.12
 
 - Updated `Card` background color for dark mode.


### PR DESCRIPTION
@tlouth19 this fixes the warning that kept showing up on pages with the ButtonMenu component. Old default icon size prop that was missed.

blocked by: https://github.com/Commerce7/admin-ui/pull/41