### PR TITLE
Updated checkbox and radio to use inline display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.8.23",
+  "version": "1.8.24",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/common/form/styles.js
+++ b/src/common/form/styles.js
@@ -88,7 +88,7 @@ const StyledLabel = styled.label`
 `;
 
 const StyledToggleLabel = styled.label`
-  display: flex;
+  display: inline-flex;
   align-items: center;
   margin-bottom: 3px;
   transition: all 0.3s ease-in-out;

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,12 @@
 
 # Release Notes
 
+#### 1.8.24
+
+- Updated `Checkbox` and `Radio` styles.
+
+---
+
 #### 1.8.23
 
 - Internal eslint improvements.


### PR DESCRIPTION
@JakeHildy this fixes a small issue with the checkboxes/radios: https://app.shortcut.com/commerce7/story/1405/update-checkbox-to-inline-flex-to-avoid-accidental-checking-off