### PR TITLE
Added error color to global theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ import Tag from './tag';
 import Text from './text';
 import Textarea from './textarea';
 import Commerce7AdminUI from './ui';
+import { c7Colors } from './ui/theme';
 import VividIcon from './vividIcon';
 
 export {
@@ -39,6 +40,7 @@ export {
   Breadcrumbs,
   Button,
   ButtonMenu,
+  c7Colors,
   Commerce7AdminUI,
   Checkbox,
   CheckboxGroup,

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,12 @@
 
 # Release Notes
 
+#### 1.9.4
+
+- Added errorColor to theme (`theme.c7__ui.errorColor`)
+
+---
+
 #### 1.9.3
 
 - Updated global color config.

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -74,6 +74,11 @@ const linkColors = {
   dark: c7Colors.blue300
 };
 
+const errorColors = {
+  light: c7Colors.red300,
+  dark: c7Colors.red300
+};
+
 export const createTheme = (mode) => ({
   c7__ui: {
     mode,
@@ -88,6 +93,7 @@ export const createTheme = (mode) => ({
     backgroundColor: backgroundColors[mode],
     secondaryBackgroundColor: secondaryBackgroundColors[mode],
     borderColor: borderColors[mode],
+    errorColor: errorColors[mode],
     borderRadius: '3px',
     boxShadow: boxShadow[mode],
     colors: c7Colors,


### PR DESCRIPTION
@JakeHildy there are lots of spots in admin where we need a red for errors, and instead of always guessing on which red to use I added an errorColor to the theme here (currently they are the same for dark and light mode). 

Also added the color object as an export in admin-ui. We have lots of theme files in admin that need the hex colors updated, but they can't access the styled components theme because they're in a theme.js file or similar. I didn't add this to the release notes, because it would be nice to remove this once all of the admin components are brought over to admin-ui.