### PR TITLE
Fixed Step propType warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.9.7",
+  "version": "1.9.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.9.9",
+  "version": "1.9.10",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/stepper/Step.js
+++ b/src/stepper/Step.js
@@ -83,7 +83,7 @@ Step.propTypes = {
   /**
    * The step number.
    */
-  step: PropTypes.string,
+  step: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
   /**
    * The step label.

--- a/src/stepper/Step.js
+++ b/src/stepper/Step.js
@@ -83,7 +83,7 @@ Step.propTypes = {
   /**
    * The step number.
    */
-  step: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  step: PropTypes.number,
 
   /**
    * The step label.

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -6,7 +6,7 @@
 
 #### 1.9.10
 
-- Fixed `Step` prop types. `Step` can now take a number or a string for `step` prop.
+- Updated `Step` prop type from string to number.
 
 ---
 

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,12 @@
 
 # Release Notes
 
+#### 1.9.10
+
+- Fixed `Step` prop types. `Step` can now take a number or a string for `step` prop.
+
+---
+
 #### 1.9.9
 
 - Fixed typo in documentation for `ButtonMenu`


### PR DESCRIPTION
@tlouth19 the step component was throwing a warning cause it was expecting a string for the step prop but we were giving it a number everywhere.