### PR TITLE
Updated Alert border colour to background colour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.9.12",
+  "version": "1.9.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.9.13",
+  "version": "1.9.14",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/alert/Alert.styles.js
+++ b/src/alert/Alert.styles.js
@@ -7,7 +7,7 @@ import { colors, sizes } from './theme';
 const StyledAlert = styled.div`
   padding: ${({ size }) => sizes[size].padding};
   border-radius: 3px;
-  border: none;
+  border: 1px solid ${({ theme }) => theme.c7__ui.backgroundColor};
   margin-bottom: 30px;
   position: relative;
   overflow: hidden;

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,12 @@
 
 # Release Notes
 
+#### 1.9.14
+
+- Updated `Alert` border colour.
+
+---
+
 #### 1.9.13
 
 - Updated `Modal` css.


### PR DESCRIPTION
@tlouth19 this updates the alert to have a border colour equal to the background colour so that the alerts on alternate background look better.

![Screen Shot 2022-04-26 at 3 04 59 PM](https://user-images.githubusercontent.com/64668108/165400161-c047b13a-a785-481f-b9da-aa8b78a4c873.png)

