### PR TITLE
Updated infoCard prop types and Grid minmax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/infoCard/InfoCard.js
+++ b/src/infoCard/InfoCard.js
@@ -90,17 +90,17 @@ InfoCard.propTypes = {
   /**
    * The label for the component.
    */
-  label: PropTypes.string,
+  label: PropTypes.node,
 
   /**
    * The title for the component.
    */
-  title: PropTypes.string,
+  title: PropTypes.node,
 
   /**
    * The subtitle for the component.
    */
-  subtitle: PropTypes.string,
+  subtitle: PropTypes.node,
 
   /**
    * Set the visual property of the component.

--- a/src/infoCard/InfoCard.styles.js
+++ b/src/infoCard/InfoCard.styles.js
@@ -4,7 +4,7 @@ import { colors } from './theme';
 
 const StyledInfoCardGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(275px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(225px, 1fr));
   gap: 20px;
   align-items: stretch;
   margin-bottom: 20px;

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,12 @@
 
 # Release Notes
 
+#### 1.10.3
+
+- Updated `InfoCard` component to accept `node` type props for title, subtitle and label props.
+
+---
+
 #### 1.10.2
 
 - Updated NPM packages.


### PR DESCRIPTION
@tlouth19 this updates the infoCard component to accept node type on the title, subtitle and label props. Also tweaked the grid wrapper minmax to 225px so it will match closer to the existing widths.