### PR TITLE
Fixed prop type bug in Alert component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/alert/Alert.js
+++ b/src/alert/Alert.js
@@ -41,7 +41,7 @@ Alert.propTypes = {
   /**
    * Set the visual property of the component.
    */
-  variant: PropTypes.oneOf(['default', 'info', 'error', 'warning']),
+  variant: PropTypes.oneOf(['default', 'info', 'error', 'warning', 'success']),
 
   /**
    * Set the size fo the component.

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,12 @@
 
 # Release Notes
 
+#### 1.10.6
+
+- Added `success` variant to `Alert` prop-types.
+
+---
+
 #### 1.10.5
 
 - Updated NPM packages.


### PR DESCRIPTION
@JakeHildy `success` was missing in the prop type array