### PR TITLE
Fixed dropdown overflow on smaller viewports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.10.10",
+  "version": "1.10.11",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.10.11",
+  "version": "1.10.12",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/common/dropdown/DropdownMenu.js
+++ b/src/common/dropdown/DropdownMenu.js
@@ -1,9 +1,15 @@
-import { forwardRef } from 'react';
+/* globals window, document */
+
+import { forwardRef, useEffect } from 'react';
+
+import useWindowSize from '../../utils/hooks/useWindowSize';
 
 import { StyledDropdown } from './DropdownMenu.styles';
 
 const DropdownMenu = forwardRef((props, ref) => {
   const { align, children, id, labelledbyId, isVisible } = props;
+
+  useViewportContainment(id, align);
 
   return (
     <StyledDropdown
@@ -18,5 +24,31 @@ const DropdownMenu = forwardRef((props, ref) => {
     </StyledDropdown>
   );
 });
+
+const useViewportContainment = (id, align) => {
+  const { width } = useWindowSize();
+
+  useEffect(() => {
+    const node = document.getElementById(id);
+    if (node) {
+      const rect = node.getBoundingClientRect();
+      const { right, left } = rect;
+      const offset = 10;
+
+      if (align === 'left') {
+        if (right > window.innerWidth) {
+          const diff = right - window.innerWidth + offset;
+          node.style.left = `-${diff}px`;
+        }
+      }
+      if (align === 'right') {
+        if (left < 0) {
+          const diff = Math.abs(left) + offset;
+          node.style.right = `-${diff}px`;
+        }
+      }
+    }
+  }, [id, width, align]);
+};
 
 export default DropdownMenu;

--- a/src/common/dropdown/DropdownMenu.js
+++ b/src/common/dropdown/DropdownMenu.js
@@ -1,4 +1,4 @@
-/* globals window, document */
+/* globals document */
 
 import { forwardRef, useEffect } from 'react';
 
@@ -9,7 +9,7 @@ import { StyledDropdown } from './DropdownMenu.styles';
 const DropdownMenu = forwardRef((props, ref) => {
   const { align, children, id, labelledbyId, isVisible } = props;
 
-  useViewportContainment(id, align);
+  useViewportContainment(id, align, isVisible);
 
   return (
     <StyledDropdown
@@ -25,19 +25,27 @@ const DropdownMenu = forwardRef((props, ref) => {
   );
 });
 
-const useViewportContainment = (id, align) => {
+const useViewportContainment = (id, align, isVisible) => {
   const { width } = useWindowSize();
 
   useEffect(() => {
     const node = document.getElementById(id);
     if (node) {
+      // Reset back to default values for proper calculation
+      if (align === 'left') {
+        node.style.left = `0px`;
+      }
+      if (align === 'right') {
+        node.style.right = `0px`;
+      }
+
       const rect = node.getBoundingClientRect();
       const { right, left } = rect;
       const offset = 10;
 
       if (align === 'left') {
-        if (right > window.innerWidth) {
-          const diff = right - window.innerWidth + offset;
+        if (right > width) {
+          const diff = right - width + offset;
           node.style.left = `-${diff}px`;
         }
       }
@@ -48,7 +56,7 @@ const useViewportContainment = (id, align) => {
         }
       }
     }
-  }, [id, width, align]);
+  }, [id, width, align, isVisible]);
 };
 
 export default DropdownMenu;

--- a/src/common/dropdown/DropdownMenu.styles.js
+++ b/src/common/dropdown/DropdownMenu.styles.js
@@ -12,11 +12,11 @@ const StyledDropdown = styled.div`
   border: 1px solid;
   position: absolute;
   top: 100%;
-  left: ${({ align }) => (align === 'left' ? '0' : 'auto')};
-  right: ${({ align }) => (align === 'right' ? '0' : 'auto')};
+  left: ${({ align }) => (align === 'left' ? '0px' : 'auto')};
+  right: ${({ align }) => (align === 'right' ? '0px' : 'auto')};
   padding: 5px;
   z-index: 999;
-  transition: all 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
   max-width: 80vw;
 
   background: ${({ theme }) =>

--- a/src/common/dropdown/DropdownMenu.styles.js
+++ b/src/common/dropdown/DropdownMenu.styles.js
@@ -17,6 +17,7 @@ const StyledDropdown = styled.div`
   padding: 5px;
   z-index: 999;
   transition: all 0.2s ease-in-out;
+  max-width: 80vw;
 
   background: ${({ theme }) =>
     dropdownColors[theme.c7__ui.mode].backgroundColor.default};

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,12 @@
 
 # Release Notes
 
+#### 1.10.11
+
+- Improved `ContextMenu` and `ButtonMenu` css on smaller viewports.
+
+---
+
 #### 1.10.10
 
 - Improved `Tabs` css on smaller viewports.

--- a/src/utils/hooks/useWindowSize.js
+++ b/src/utils/hooks/useWindowSize.js
@@ -1,0 +1,27 @@
+/* globals window */
+
+import { useEffect, useState } from 'react';
+
+const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState({
+    width: window.innerWidth,
+    height: window.innerHeight
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight
+      });
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowSize;
+};
+
+export default useWindowSize;


### PR DESCRIPTION
@JakeHildy this fixes both the ContextMenu and ButtonMenu, and should not kill the viewport on small screens anymore.