### PR TITLE
Bump AdminUI package and release notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.10.58",
+  "version": "1.10.59",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.10.58",
+      "version": "1.10.59",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.10.58",
+  "version": "1.10.59",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/alert/Alert.stories.js
+++ b/src/alert/Alert.stories.js
@@ -11,7 +11,7 @@ export const Variants = () => (
     <Alert variant="error">This is a red error alert</Alert>
     <Alert variant="info">This is a blue info alert</Alert>
     <Alert variant="warning" icon="warning">
-      This is a yellow warning alert
+      This is an orange warning alert
     </Alert>
     <Alert variant="default">This is a grey default alert</Alert>
     <Alert variant="success">This is a green success alert</Alert>
@@ -31,7 +31,7 @@ export const Small = () => (
       This is a blue info alert
     </Alert>
     <Alert variant="warning" size="small" icon="warning">
-      This is a yellow warning alert
+      This is an orange warning alert
     </Alert>
     <Alert variant="default" size="small">
       This is a grey default alert

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,10 @@
 
 # Release Notes
 
+#### 1.10.59
+
+- Adds new orange colors and applies to Alert `warning` variant.
+
 #### 1.10.58
 
 - Updated NPM packages.


### PR DESCRIPTION
@NoahThomlison we forgot to bump package so deployment failed when trying to publish to npm. This new PR bumps the package and `npm i` to update package-lock. Also updates stories so it makes a bit more sense