### PR TITLE
Add level 4 Heading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.10.86",
+  "version": "1.10.87",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.10.86",
+      "version": "1.10.87",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.10.86",
+  "version": "1.10.87",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/heading/Heading.js
+++ b/src/heading/Heading.js
@@ -8,6 +8,7 @@ const Heading = (props) => {
   let as = 'h2';
   if (level === 1) as = 'h1';
   else if (level === 3) as = 'h3';
+  else if (level === 4) as = 'h4';
 
   return (
     <StyledHeading as={as} className={className} data-testid={dataTestId}>
@@ -26,7 +27,7 @@ Heading.propTypes = {
   /**
    * Select what size heading.
    */
-  level: PropTypes.oneOf([1, 2, 3]),
+  level: PropTypes.oneOf([1, 2, 3, 4]),
 
   /**
    * The content of the component.

--- a/src/heading/Heading.stories.js
+++ b/src/heading/Heading.stories.js
@@ -5,6 +5,7 @@ export const Basic = () => (
     <Heading level={1}>Heading 1</Heading>
     <Heading level={2}>Heading 2</Heading>
     <Heading level={3}>Heading 3</Heading>
+    <Heading level={4}>Heading 4</Heading>
   </>
 );
 

--- a/src/heading/Heading.styles.js
+++ b/src/heading/Heading.styles.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { fontSize, colors } from './theme';
+import { fontSize, colors, marginBottom } from './theme';
 
 const StyledHeading = styled.h2`
   font-weight: ${({ theme }) => theme.c7__ui.fontWeightBase};
@@ -8,7 +8,7 @@ const StyledHeading = styled.h2`
   color: ${({ theme }) => colors[theme.c7__ui.mode].fontColor};
 
   transition: color 0.3s ease-in-out;
-  margin: 0 0 20px 0;
+  margin: 0 0 ${({ as }) => marginBottom[as]} 0;
   font-size: ${({ as }) => fontSize[as]};
   line-height: 1.4;
 `;

--- a/src/heading/theme.js
+++ b/src/heading/theme.js
@@ -3,7 +3,15 @@ import { c7Colors } from '../ui/theme';
 const fontSize = {
   h1: '32px',
   h2: '24px',
-  h3: '20px'
+  h3: '20px',
+  h4: '18px'
+};
+
+const marginBottom = {
+  h1: '20px',
+  h2: '20px',
+  h3: '20px',
+  h4: '15px'
 };
 
 const colors = {
@@ -15,4 +23,4 @@ const colors = {
   }
 };
 
-export { fontSize, colors };
+export { fontSize, colors, marginBottom };

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -4,6 +4,10 @@
 
 # Release Notes
 
+#### 1.10.87
+
+- Added level 4 prop to `Heading` component.
+
 #### 1.10.86
 
 - Updated NPM packages.


### PR DESCRIPTION
@andreadyck this adds h4 headings to Admin-ui. We override level 3's all the time to have 18px font-size so this is one "incremental step" towards being able to remove some of the custom styles in admin.

![Screenshot 2023-03-17 at 1 20 22 PM](https://user-images.githubusercontent.com/64668108/226028301-cc72a7e6-4093-4a11-ba7b-036c8d812f2e.png)
