### PR TITLE
updates to remove children from the required on buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.23",
+  "version": "1.11.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.11.23",
+      "version": "1.11.24",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.23",
+  "version": "1.11.24",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/button/Button.js
+++ b/src/button/Button.js
@@ -41,6 +41,7 @@ const Button = forwardRef((props, ref) => {
             icon={startIcon}
             position="start"
             isHidden={loading}
+            hasChildren={children !== null}
           />
         )}
         {loading && <StyledLoadingIcon icon="loading" />}
@@ -51,6 +52,7 @@ const Button = forwardRef((props, ref) => {
             icon={endIcon}
             position="end"
             isHidden={loading}
+            hasChildren={children !== null}
           />
         )}
       </StyledButtonText>
@@ -59,6 +61,7 @@ const Button = forwardRef((props, ref) => {
 });
 
 Button.defaultProps = {
+  children: null,
   className: '',
   disabled: false,
   loading: false,
@@ -74,7 +77,7 @@ Button.propTypes = {
   /**
    * The content of the component.
    */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
 
   /**
    * Add className to the outermost element.

--- a/src/button/Button.stories.js
+++ b/src/button/Button.stories.js
@@ -89,6 +89,7 @@ Size.story = {
 
 export const Icon = () => (
   <StyledContainer>
+    <Button variant="primary" startIcon="add" />
     <Button variant="primary" startIcon="add">
       Add to Cart
     </Button>

--- a/src/button/Button.styles.js
+++ b/src/button/Button.styles.js
@@ -6,7 +6,8 @@ import { sizes, colors, shadows } from './theme';
 
 const StyledButtonIcon = styled(Icon)`
   opacity: ${({ isHidden }) => (isHidden ? 0 : 1)};
-  margin: ${({ position, buttonVariant }) => {
+  margin: ${({ position, buttonVariant, hasChildren, icon }) => {
+    if (!hasChildren && icon) return '0px';
     const iconMargin = buttonVariant === 'link' ? '5px' : '10px';
     return position === 'start' ? `0 ${iconMargin} 0 0` : `0 0 0 ${iconMargin}`;
   }};

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -6,6 +6,12 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.11.24
+
+- Changes children on buttons to null be default instead of required.
+- Changes styling on buttons when no children are passed in.
+- Adds example without children to Icon story
+
 #### 1.11.23
 
 - Updated NPM packages.


### PR DESCRIPTION
### Current Issue
Currently buttons require children. This is an issue when we want a button without text but with an icon.

### Fix
Remove children from required and give it a default value of null
Update styling to remove the margins from the icon when there is no children present
Add example of new button styling to story for Icon button

### Testing
<img width="1487" alt="image" src="https://github.com/Commerce7/admin-ui/assets/80222250/fb23d03a-50a8-4267-b264-75b23b2c4b55">
