### PR TITLE
updates link button with new props, changes children to not required,…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.24",
+  "version": "1.11.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.11.24",
+      "version": "1.11.25",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.24",
+  "version": "1.11.25",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/linkButton/LinkButton.js
+++ b/src/linkButton/LinkButton.js
@@ -49,6 +49,7 @@ const LinkButton = forwardRef((props, ref) => {
           buttonVariant={variant}
           icon={startIcon}
           position="start"
+          hasChildren={children !== null}
         />
       )}
       {children}
@@ -57,6 +58,7 @@ const LinkButton = forwardRef((props, ref) => {
           buttonVariant={variant}
           icon={endIcon}
           position="end"
+          hasChildren={children !== null}
         />
       )}
     </StyledButton>
@@ -64,6 +66,7 @@ const LinkButton = forwardRef((props, ref) => {
 });
 
 LinkButton.defaultProps = {
+  children: null,
   className: '',
   component: null,
   disabled: false,
@@ -81,7 +84,7 @@ LinkButton.propTypes = {
   /**
    * The content of the component.
    */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
 
   /**
    * Add className to the outermost element

--- a/src/linkButton/LinkButton.stories.js
+++ b/src/linkButton/LinkButton.stories.js
@@ -16,6 +16,20 @@ Basic.story = {
 
 export const Variants = () => (
   <StyledContainer>
+    <LinkButton
+      variant="primary"
+      startIcon="add"
+      href="https://commerce7.com"
+    />
+    <LinkButton variant="primary" href="https://commerce7.com">
+      Primary Button
+    </LinkButton>
+    <LinkButton variant="primary" startIcon="add" href="https://commerce7.com">
+      Primary Button
+    </LinkButton>
+    <LinkButton variant="primary" endIcon="add" href="https://commerce7.com">
+      Primary Button
+    </LinkButton>
     <LinkButton variant="primary" href="https://commerce7.com">
       Primary Button
     </LinkButton>

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.11.25
+
+- Updates link buttons with the same changes done to buttons on 1.11.24
+
 #### 1.11.24
 
 - Changes children on buttons to null be default instead of required.


### PR DESCRIPTION
### Current Issue
Link buttons were not updated like buttons were to not require children and to pass in a variable to correct the padding like buttons where

### Fix
Update link button

### Testing

without the fix (and added stories)
<img width="1358" alt="image" src="https://github.com/Commerce7/admin-ui/assets/80222250/af3bbbe5-b666-4c69-9457-ad466583c0bc">

with the fix
<img width="1287" alt="image" src="https://github.com/Commerce7/admin-ui/assets/80222250/02fd18c6-0238-4141-bad1-48d3c3525ff1">

