### PR TITLE
Button menu styling fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.25",
+  "version": "1.11.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.11.25",
+      "version": "1.11.26",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.25",
+  "version": "1.11.26",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/buttonMenu/ButtonMenu.js
+++ b/src/buttonMenu/ButtonMenu.js
@@ -70,7 +70,7 @@ const ButtonMenu = (props) => {
           <StyledButtonIcon
             icon="chevronDown"
             buttonVariant={variant}
-            hasChildren={children !== null}
+            hasChildren
           />
         </StyledButton>
         <DropdownMenu

--- a/src/buttonMenu/ButtonMenu.js
+++ b/src/buttonMenu/ButtonMenu.js
@@ -67,7 +67,11 @@ const ButtonMenu = (props) => {
           disabled={disabled}
         >
           {label}
-          <StyledButtonIcon icon="chevronDown" buttonVariant={variant} />
+          <StyledButtonIcon
+            icon="chevronDown"
+            buttonVariant={variant}
+            hasChildren={children !== null}
+          />
         </StyledButton>
         <DropdownMenu
           isVisible={isDropdownVisible}

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.11.26
+
+- Updates button menu buttons with the same changes done to buttons on 1.11.24
+
 #### 1.11.25
 
 - Updates link buttons with the same changes done to buttons on 1.11.24


### PR DESCRIPTION
### Current Issue
Button menu needs to be updated with new hasChildren prop so that the styling is correct

### Fix
Since on a buttonMenu the children are required I simply pass true in instead of the logic on the other buttons

### Testing
with
<img width="323" alt="image" src="https://github.com/Commerce7/admin-ui/assets/80222250/8bc32091-11e7-407f-a934-52549c898d11">

without
<img width="323" alt="image" src="https://github.com/Commerce7/admin-ui/assets/80222250/56e433e9-3869-4995-944a-eaa61a7bbd79">

