### PR TITLE
More Actions override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.28",
+  "version": "1.11.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.11.28",
+      "version": "1.11.29",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.28",
+  "version": "1.11.29",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/contextMenu/ContextMenu.stories.js
+++ b/src/contextMenu/ContextMenu.stories.js
@@ -50,6 +50,23 @@ Disabled.story = {
   name: 'Disabled'
 };
 
+export const MoreActionsOverride = () => (
+  <ContextMenu>
+    <ContextMenuItem icon="export" onClick={action('clicked')}>
+      Export
+    </ContextMenuItem>
+    <ContextMenuMoreActions label="Actions">
+      <ContextMenuItem icon="trash" onClick={action('clicked')}>
+        Delete
+      </ContextMenuItem>
+    </ContextMenuMoreActions>
+  </ContextMenu>
+);
+
+MoreActionsOverride.story = {
+  name: 'MoreActionsOverride'
+};
+
 const description = `
 import { ContextMenu } from '@commerce7/admin-ui'<br/><br/>const { ContextMenuItem, ContextMenuMoreActions } = ContextMenu
 `;

--- a/src/contextMenu/ContextMenuMoreActions.js
+++ b/src/contextMenu/ContextMenuMoreActions.js
@@ -11,7 +11,7 @@ import useEscKeydown from '../utils/hooks/useEscKeydown';
 import useOnClickOutside from '../utils/hooks/useOnClickOutside';
 
 const ContextMenuMoreActions = (props) => {
-  const { children, className, disabled, dataTestId } = props;
+  const { children, className, disabled, dataTestId, label } = props;
 
   const [isValidChildren, setValidChildren] = useState(true);
   const wrapperRef = useRef();
@@ -59,7 +59,7 @@ const ContextMenuMoreActions = (props) => {
         ref={buttonRef}
       >
         <StyledContextMenuIcon icon="moreActions" />
-        More Actions
+        {label}
       </StyledContextMenuItem>
       <DropdownMenu
         ref={dropdownRef}
@@ -77,7 +77,8 @@ const ContextMenuMoreActions = (props) => {
 ContextMenuMoreActions.defaultProps = {
   className: null,
   disabled: false,
-  dataTestId: null
+  dataTestId: null,
+  label: 'More Actions'
 };
 
 ContextMenuMoreActions.propTypes = {
@@ -91,6 +92,11 @@ ContextMenuMoreActions.propTypes = {
    * Add className to the outermost element.
    */
   className: PropTypes.string,
+
+  /**
+   * Override the default label of "More Actions".
+   */
+  label: PropTypes.string,
 
   /**
    * Set the element to disabled.

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.11.29
+
+- Added `label` prop to `ContextMenuMoreActions` component which allows the ability to override the default "More Actions" label.
+
 #### 1.11.28
 
 - Updated major NPM packages.


### PR DESCRIPTION
@NoahThomlison this allows us to pass in a "label" prop to the ContextMenuMoreActions so we can override the default "More Actions" label if we want.

![Screenshot 2023-07-25 at 9 24 14 AM](https://github.com/Commerce7/admin-ui/assets/64668108/8d2560da-8e51-4d69-abca-b2220321a0c9)
