### PR TITLE
Sc 8538 update pie chart component to render custom inline legend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.53",
+  "version": "1.11.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.11.53",
+      "version": "1.11.54",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.53",
+  "version": "1.11.54",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/legend/Legend.js
+++ b/src/legend/Legend.js
@@ -84,7 +84,7 @@ Legend.propTypes = {
   /**
    *  The width of legend
    */
-  width: PropTypes.string,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /**
    *  The header title of legend
    */

--- a/src/legend/Legend.js
+++ b/src/legend/Legend.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import Text from '../text';
 
 const Legend = (props) => {
-  const { data, width, legendHeader } = props;
+  const { data, width, legendHeader, isVertical = false } = props;
 
   const renderCircle = (color) => (
     <svg height="14" width="14">
@@ -13,12 +13,12 @@ const Legend = (props) => {
   );
 
   return (
-    <LegendStyledWrapper width={width}>
+    <LegendStyledWrapper width={width} isVertical={isVertical}>
       {legendHeader && <StyledLegendHeader>{legendHeader}</StyledLegendHeader>}
       {data.map((legend) => (
         <StyledLegendItem key={`item-${legend.title}`}>
           <StyledCircle>{renderCircle(legend.color)}</StyledCircle>
-          <Text>{legend.title}</Text>
+          {legend.title && <Text>{legend.title}</Text>}
           <StyledValueText>{legend.value}</StyledValueText>
         </StyledLegendItem>
       ))}
@@ -28,11 +28,13 @@ const Legend = (props) => {
 
 const LegendStyledWrapper = styled.div`
   display: flex;
-  flex-direction: column;
-  row-gap: 8px;
-  ${({ width }) => `
-    width: ${width};
-  `}
+  gap: 8px;
+  flex-direction: row;
+  ${({ isVertical, width }) =>
+    isVertical &&
+    `flex-direction: column; 
+     row-gap: 8px;
+     width: ${width};`};
 `;
 
 const StyledLegendItem = styled.div`
@@ -42,6 +44,8 @@ const StyledLegendItem = styled.div`
 `;
 
 const StyledCircle = styled.div`
+  display: flex;
+  align-items: center;
   margin-right: 5px;
 `;
 
@@ -56,6 +60,7 @@ const StyledLegendHeader = styled(Text)`
 
 Legend.defaultProps = {
   width: '15%',
+  isVertical: false,
   legendHeader: ''
 };
 
@@ -70,6 +75,12 @@ Legend.propTypes = {
       color: PropTypes.string
     })
   ).isRequired,
+
+  /**
+   *  Renders legends vertically if it is true
+   */
+  isVertical: PropTypes.bool,
+
   /**
    *  The width of legend
    */

--- a/src/legend/Legend.stories.js
+++ b/src/legend/Legend.stories.js
@@ -16,16 +16,35 @@ const legendData2 = [
   { title: 'Club Member', value: '$78', color: '#239C82' }
 ];
 
-export const Basic = (args) => (
+const legendDataWithoutValue = [
+  { title: 'Guest', color: '#42ACF0' },
+  { title: 'First-time', color: '#DF5F5F' },
+  { title: 'Repeat', color: '#BF9D36' },
+  { title: 'Club Member', color: '#239C82' }
+];
+
+export const Default = (args) => (
   <div>
-    <Legend data={legendData} {...args} />
+    <Legend isVertical={false} data={legendDataWithoutValue} {...args} />
   </div>
 );
 
-export const Grouped = (args) => (
+export const Vertical = (args) => (
+  <div>
+    <Legend data={legendData} isVertical {...args} />
+  </div>
+);
+
+export const GroupedVertical = (args) => (
   <div style={{ display: 'flex', gap: 100 }}>
-    <Legend data={legendData} legendHeader="By Channel" {...args} />
-    <Legend data={legendData2} legendHeader="By Customer Type" {...args} />
+    <Legend data={legendData} legendHeader="By Channel" isVertical {...args} />
+    <Legend
+      data={legendData2}
+      width="50%"
+      legendHeader="By Customer Type"
+      isVertical
+      {...args}
+    />
   </div>
 );
 

--- a/src/legend/Legend.stories.js
+++ b/src/legend/Legend.stories.js
@@ -37,10 +37,16 @@ export const Vertical = (args) => (
 
 export const GroupedVertical = (args) => (
   <div style={{ display: 'flex', gap: 100 }}>
-    <Legend data={legendData} legendHeader="By Channel" isVertical {...args} />
+    <Legend
+      data={legendData}
+      width="30%"
+      legendHeader="By Channel"
+      isVertical
+      {...args}
+    />
     <Legend
       data={legendData2}
-      width="50%"
+      width="30%"
       legendHeader="By Customer Type"
       isVertical
       {...args}

--- a/src/pieChart/PieChart.js
+++ b/src/pieChart/PieChart.js
@@ -127,7 +127,7 @@ PieChart.propTypes = {
   outerRadius: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
   /**
-   *The prop to add positioning to PieChart.
+   *The prop to add positioning to PieChart. Refer: https://recharts.org/en-US/api/PieChart#margin
    */
   margin: PropTypes.shape({}),
 
@@ -136,7 +136,7 @@ PieChart.propTypes = {
    */
   label: PropTypes.element,
   /**
-   * The prop to add positioning to legend component. Ex: {position:'relative', left:0, bottom:0}
+   * The prop to add positioning to legend component. Refer: https://recharts.org/en-US/api/Legend#wrapperStyle
    */
   legendWrapperStyle: PropTypes.shape({}),
 
@@ -146,7 +146,7 @@ PieChart.propTypes = {
   legend: PropTypes.element,
 
   /**
-   * The prop to align legend items
+   * The prop to align legend items. Refer: https://recharts.org/en-US/api/Legend#verticalAlign
    */
   legendProps: PropTypes.shape({
     width: PropTypes.number,
@@ -156,7 +156,7 @@ PieChart.propTypes = {
   }),
 
   /**
-   * A component to render custom tooltip component
+   * A component to render custom tooltip component. Refer: https://recharts.org/en-US/api/Tooltip#content
    */
   tooltip: PropTypes.element,
 

--- a/src/pieChart/PieChart.stories.js
+++ b/src/pieChart/PieChart.stories.js
@@ -77,7 +77,8 @@ export default {
     controls: { expanded: true },
     docs: {
       description: {
-        component: "import { PieChart } from '@commerce7/admin-ui'"
+        component:
+          "import { PieChart } from '@commerce7/admin-ui' \n\n This chart is implemented using the Recharts library. For more details on how to customize and use Recharts, please refer to the [Recharts documentation](https://recharts.org/)."
       }
     }
   }

--- a/src/pieChart/PieChart.stories.js
+++ b/src/pieChart/PieChart.stories.js
@@ -1,5 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
+import Legend from '../legend/Legend';
+
 import Label from './Label';
 import ToolTip from './Tooltip';
 
@@ -26,6 +28,41 @@ export const Basic = (args) => {
         data={data}
         colors={colors}
         label={<Label />}
+        tooltip={<ToolTip />}
+        {...args}
+      />
+    </div>
+  );
+};
+
+export const ChartWithCustomLegend = (args) => {
+  const data = [
+    { name: 'Group A', value: 400 },
+    {
+      name: 'Group B',
+      value: 288
+    },
+    {
+      name: 'Group C',
+      value: 100
+    }
+  ];
+
+  const legendData = [
+    { title: 'Group A', color: '#42ACF0' },
+    { title: 'Group B', color: '#DF5F5F' },
+    { title: 'Group C', color: '#BF9D36' }
+  ];
+  const colors = ['#42ACF0', '#DF5F5F', '#BF9D36'];
+
+  return (
+    <div style={{ height: 300 }}>
+      <PieChart
+        data={data}
+        colors={colors}
+        label={<Label />}
+        legendProps={{ layout: 'vertical' }}
+        legend={<Legend data={legendData} />}
         tooltip={<ToolTip />}
         {...args}
       />

--- a/src/pieChart/PieChart.stories.js
+++ b/src/pieChart/PieChart.stories.js
@@ -35,7 +35,7 @@ export const Basic = (args) => {
   );
 };
 
-export const ChartWithCustomLegend = (args) => {
+export const WithCustomLegend = (args) => {
   const data = [
     { name: 'Group A', value: 400 },
     {

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -6,6 +6,11 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.11.54
+
+- Adds isVertical prop to `Legend` component to render vertical layout.
+- Adds new custom legend story doc to `PieChart`.
+
 #### 1.11.51
 
 - Adds `ProgressBar` component.


### PR DESCRIPTION
@JakeHildy @andreadyck 

I added isVertical prob to Legend so that when ever it is true the Legend is going to render vertically. Otherwise it will render inline.

I also created a story in the PieChart storybook doc that is  **With Custom Legend** so that Pablo can use this example to create PieChart with Inline Legend instead of using the one in the Recharts.


FYI: Once this one is merged. I am going to update admin to use isVertical in the reporting.

PieChart stories;
<img width="1117" alt="image" src="https://github.com/Commerce7/admin-ui/assets/20227401/f4634b31-9227-46e4-9714-7f69ad763e1c">


Legend Stories;
<img width="1090" alt="image" src="https://github.com/Commerce7/admin-ui/assets/20227401/b9487cb6-9e76-41cd-956f-5126ac39ba0f">


