### PR TITLE
add novalidation prop to button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.54",
+  "version": "1.11.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.11.54",
+      "version": "1.11.56",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.55",
+  "version": "1.11.56",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/button/Button.js
+++ b/src/button/Button.js
@@ -21,7 +21,7 @@ const Button = forwardRef((props, ref) => {
     variant,
     size,
     dataTestId,
-    formnovalidate
+    formNoValidate
   } = props;
 
   return (
@@ -34,7 +34,7 @@ const Button = forwardRef((props, ref) => {
       variant={variant}
       size={size}
       data-testid={dataTestId}
-      formNoValidate={formnovalidate}
+      formNoValidate={formNoValidate}
     >
       <StyledButtonText isLoading={loading}>
         {startIcon && (
@@ -73,7 +73,7 @@ Button.defaultProps = {
   variant: 'primary',
   size: 'default',
   dataTestId: null,
-  formnovalidate: false
+  formNoValidate: false
 };
 
 Button.propTypes = {
@@ -134,7 +134,7 @@ Button.propTypes = {
    * When it is true, it specifies that the <input> element should not be validated when submitted.
    * Use this when you have custom validation on your form
    */
-  formnovalidate: PropTypes.bool
+  formNoValidate: PropTypes.bool
 };
 
 export default Button;

--- a/src/button/Button.js
+++ b/src/button/Button.js
@@ -20,7 +20,8 @@ const Button = forwardRef((props, ref) => {
     type,
     variant,
     size,
-    dataTestId
+    dataTestId,
+    formnovalidate
   } = props;
 
   return (
@@ -33,6 +34,7 @@ const Button = forwardRef((props, ref) => {
       variant={variant}
       size={size}
       data-testid={dataTestId}
+      formNoValidate={formnovalidate}
     >
       <StyledButtonText isLoading={loading}>
         {startIcon && (
@@ -70,7 +72,8 @@ Button.defaultProps = {
   type: 'button',
   variant: 'primary',
   size: 'default',
-  dataTestId: null
+  dataTestId: null,
+  formnovalidate: false
 };
 
 Button.propTypes = {
@@ -125,7 +128,13 @@ Button.propTypes = {
   /**
    * Add test attribute to the element. Used internally for testing.
    */
-  dataTestId: PropTypes.string
+  dataTestId: PropTypes.string,
+
+  /**
+   * When it is true, it specifies that the <input> element should not be validated when submitted.
+   * Use this when you have custom validation on your form
+   */
+  formnovalidate: PropTypes.bool
 };
 
 export default Button;

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -8,7 +8,7 @@ import { Meta } from '@storybook/blocks';
 
 #### 1.11.56
 
-- Adds formNoValidate to disable html input validation
+- Adds `formNoValidate` prop to `Button` component to disable html input validation if necessary.
 
 #### 1.11.55
 

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.11.56
+
+- Adds formnovalidate to disable html input validation
+
 #### 1.11.55
 
 - Updated NPM packages.

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -8,7 +8,7 @@ import { Meta } from '@storybook/blocks';
 
 #### 1.11.56
 
-- Adds formnovalidate to disable html input validation
+- Adds formNoValidate to disable html input validation
 
 #### 1.11.55
 


### PR DESCRIPTION
@JakeHildy This will help us enable/disable form validation that comes from HTML. So that the required pop up that comes from HTML will be gone if you make this true.