### PR TITLE
update errorColor dark theme color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.57",
+  "version": "1.11.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.11.57",
+      "version": "1.11.58",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.57",
+  "version": "1.11.58",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.11.58
+
+- Updated `errorColors` theme color.
+
 #### 1.11.57
 
 - Updated minor NPM packages.

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -84,7 +84,7 @@ const linkColors = {
 
 const errorColors = {
   light: c7Colors.red300,
-  dark: c7Colors.red300
+  dark: c7Colors.red200
 };
 
 export const createTheme = (mode) => ({


### PR DESCRIPTION
@JakeHildy 

@joshclysdale  found out that the WYSIWYG editor error message color does not match the one that we have in formik.
I just realized that we don't have a light color for the dark theme for errorMessage.This change will fix this issue that is down below;

