### PR TITLE
Sc 9083 change admin UI font

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -6,6 +6,7 @@ addons.setConfig({
     base: 'light',
     brandTitle: 'Commerce7 Admin UI',
     brandUrl: 'https://commerce7.com',
-    brandImage: '/logo.png'
+    brandImage: '/logo.png',
+    fontBase: '"Inter", sans-serif'
   })
 });

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,4 +1,5 @@
 <link
-  href="https://fonts.googleapis.com/css2?family=Alegreya+Sans:wght@300&family=Nunito:wght@400;600&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Alegreya+Sans:wght@300&family=Inter
+  :wght@400;600&display=swap"
   rel="stylesheet"
 />

--- a/README.md
+++ b/README.md
@@ -12,26 +12,26 @@ npm install @commerce7/admin-ui
 
 <br />
 
-## Nunito Font
+## Inter Font
 
-Commerce7 Admin UI was designed to be used with Nunito, available for free from <a href='https://fonts.google.com/specimen/Nunito' target='_blank'>Google Fonts</a>. Nunito can be included in your application inside of HTML or from NPM.
+Commerce7 Admin UI was designed to be used with Inter, available for free from <a href='https://fonts.google.com/specimen/Inter' target='_blank'>Google Fonts</a>. Inter can be included in your application inside of HTML or from NPM.
 
 In HTML:
 
 ```
 <link rel="preconnect" href="https://fonts.gstatic.com">
-<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@300;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
 ```
 
 With NPM:
 
 ```
-npm install @fontsource/nunito
+npm install @fontsource/inter
 ```
 
 ```
-import "@fontsource/nunito/300.css"
-import "@fontsource/nunito/600.css"
+import "@fontsource/inter/400.css";
+import "@fontsource/inter/600.css";
 ```
 
 <br />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.61",
+  "version": "1.11.62",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/stories/Introduction.stories.mdx
+++ b/src/stories/Introduction.stories.mdx
@@ -20,26 +20,26 @@ npm install @commerce7/admin-ui
 
 <br />
 
-## Nunito Font
+## Inter Font
 
-Commerce7 Admin UI was designed to be used with Nunito, available for free from <a href='https://fonts.google.com/specimen/Nunito' target='_blank'>Google Fonts</a>. Nunito can be included in your application inside of HTML or from NPM.
+Commerce7 Admin UI was designed to be used with Inter, available for free from <a href='https://fonts.google.com/specimen/Inter' target='_blank'>Google Fonts</a>. Inter can be included in your application inside of HTML or from NPM.
 
 In HTML:
 
 ```
 <link rel="preconnect" href="https://fonts.gstatic.com">
-<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
 ```
 
 With NPM:
 
 ```
-npm install @fontsource/nunito
+npm install @fontsource/inter
 ```
 
 ```
-import "@fontsource/nunito/400.css"
-import "@fontsource/nunito/600.css"
+import "@fontsource/inter/400.css";
+import "@fontsource/inter/600.css";
 ```
 
 <br />

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.11.62
+
+- Updated font to Inter
+
 #### 1.11.61
 
 - Updated `asterix color` for dark mode.

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -127,9 +127,6 @@ export const GlobalStyles = createGlobalStyle`
     -moz-box-sizing: border-box;
     box-sizing: border-box;
   }
-  .storybook-docs {
-    background-color: red;
-  }
   html, body {
     font-size:  ${({ theme }) => theme.c7__ui.fontSizeBase};
     font-family: ${({ theme }) => theme.c7__ui.fontFamily};

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -90,7 +90,7 @@ const errorColors = {
 export const createTheme = (mode) => ({
   c7__ui: {
     mode,
-    fontFamily: '"Nunito", sans-serif',
+    fontFamily: '"Inter", sans-serif',
     fontSizeBase: '15px',
     fontSizeSmall: '14px',
     fontWeightBase: '400',
@@ -126,6 +126,9 @@ export const GlobalStyles = createGlobalStyle`
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
+  }
+  .storybook-docs {
+    background-color: red;
   }
   html, body {
     font-size:  ${({ theme }) => theme.c7__ui.fontSizeBase};


### PR DESCRIPTION
<img width="1087" alt="image" src="https://github.com/Commerce7/admin-ui/assets/80222250/9e56c807-7974-4473-b951-34b92b50b969">

In admin ui I cannot figure out how to change the default font of storybook for the following areas below. Andrea has stated she does not care about these items
<img width="1074" alt="image" src="https://github.com/Commerce7/admin-ui/assets/80222250/5bc45068-a4bf-4c72-be72-b9d180d3ea15">
