### PR TITLE
Update table padding and tag close button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.66",
+  "version": "1.11.67",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.11.67
+- `Table`: Fixes padding for single column tables
+- `Tag`: Updates "x" icon and text color, Prevents tag text from being cut off vertically
+
 #### 1.11.66
 
 - `Table`: Padding and footer background updates

--- a/src/table/Td.styles.js
+++ b/src/table/Td.styles.js
@@ -4,11 +4,11 @@ const StyledTd = styled.td`
   text-align: ${({ align }) => align};
   padding: 15px 7px;
 
-  &:first-of-type {
+  &:first-of-type:not(:only-child) {
     padding-left: 15px;
   }
 
-  &:last-of-type {
+  &:last-of-type:not(:only-child) {
     padding-right: 15px;
   }
 `;

--- a/src/table/Tfoot.styles.js
+++ b/src/table/Tfoot.styles.js
@@ -1,13 +1,13 @@
 import styled from 'styled-components';
 
-import { tfootColors, theadColors } from './theme';
+import { tfootColors } from './theme';
 
 const StyledTfoot = styled.tfoot`
   width: 100%;
 
   tr {
     background-color: ${({ theme }) =>
-      theadColors[theme.c7__ui.mode].backgroundColor} !important;
+      tfootColors[theme.c7__ui.mode].backgroundColor} !important;
     border-top: 1px solid
       ${({ theme }) => tfootColors[theme.c7__ui.mode].borderColor};
   }

--- a/src/tag/Tag.js
+++ b/src/tag/Tag.js
@@ -33,8 +33,12 @@ const Tag = (props) => {
         data-testid={dataTestId}
       >
         <StyledTagLabel>{children}</StyledTagLabel>
-        <StyledDeleteButton onClick={handleDelete} type="button">
-          x
+        <StyledDeleteButton
+          onClick={handleDelete}
+          type="button"
+          variant={variant}
+        >
+          ✕
         </StyledDeleteButton>
       </StyledTag>
     );

--- a/src/tag/Tag.styles.js
+++ b/src/tag/Tag.styles.js
@@ -7,13 +7,13 @@ import { colors } from './theme';
 const StyledTag = styled.span`
   display: inline-flex;
   align-items: center;
-  padding: 6px 10px 7px;
+  padding: 6px 10px;
   min-height: 29px;
   border-radius: 30px;
   border: none;
   margin: 0 5px 5px 0;
   font-size: 13px;
-  line-height: 1;
+  line-height: 1.2;
   max-width: 100%;
   transition: all 0.3s ease-in-out;
 
@@ -65,10 +65,10 @@ const StyledDeleteButton = styled.button`
   margin-right: -5px;
   transition: all 0.3s ease-in-out;
   background: rgba(255, 255, 255, 0.4);
-  color: rgb(41, 50, 56);
+  color: ${({ theme, variant }) => colors[theme.c7__ui.mode][variant].color};
 
   font-family: ${({ theme }) => theme.c7__ui.fontFamily};
-  font-size: 16px;
+  font-size: 12px;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
- Tables: There was an issue with the new padding when there is only a single column in the table
![Screenshot 2023-11-20 at 4 18 06 PM](https://github.com/Commerce7/admin-ui/assets/7304753/ee2d64cd-84eb-48d2-a7b6-aa60fa73d920)
![Screenshot 2023-11-20 at 4 17 55 PM](https://github.com/Commerce7/admin-ui/assets/7304753/15b9e7be-219e-4948-95aa-545878d71412)
- Tags: "g" was getting cut off vertically
![Screenshot 2023-11-20 at 4 17 44 PM](https://github.com/Commerce7/admin-ui/assets/7304753/d897980a-4646-462d-9e09-be2a8f2405a3)
![Screenshot 2023-11-20 at 4 17 28 PM](https://github.com/Commerce7/admin-ui/assets/7304753/735f341b-06c9-4443-8a5f-1a04ecf3ace6)
- Tags: Updates "x" text to symbol and colour to match tag text
![Screenshot 2023-11-20 at 4 17 15 PM](https://github.com/Commerce7/admin-ui/assets/7304753/6cf4820d-f453-445e-a526-79c6810b5d7e)
![Screenshot 2023-11-20 at 4 17 25 PM](https://github.com/Commerce7/admin-ui/assets/7304753/6e65432e-481a-4701-bf41-5b289c6a5cd3)


