### PR TITLE
Fix table padding for single column tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.71",
+  "version": "1.11.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.11.71",
+      "version": "1.11.72",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.71",
+  "version": "1.11.72",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -6,6 +6,9 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.11.72
+- `Table`: Fixes padding for single column tables
+
 #### 1.11.71
 
 - Revert minor NPM packages.

--- a/src/table/Td.styles.js
+++ b/src/table/Td.styles.js
@@ -5,11 +5,11 @@ const StyledTd = styled.td`
   text-align: ${({ align }) => align};
   padding: 15px 7px;
 
-  &:first-of-type:not(:only-child) {
+  &:first-of-type {
     padding-left: 15px;
   }
 
-  &:last-of-type:not(:only-child) {
+  &:last-of-type {
     padding-right: 15px;
   }
 `;


### PR DESCRIPTION
## Current issue
- Right now, we have padding added to linked tables in Admin (which overrides what is set in Admin UI)
- Most of our tables have linked rows so those all display fine, but if a partner is using the table component on its own which doesn't have the linking, the table isn't aligned with the header properly when only one column exists.

I will need to make another change to Admin after this PR is through.

![Screenshot 2023-12-11 at 4 50 29 PM](https://github.com/Commerce7/admin-ui/assets/7304753/a75347fb-94cb-4471-aa11-d3d0403aa392)

## Current fix
- Fix table padding for single column tables

![Screenshot 2023-12-11 at 4 49 54 PM](https://github.com/Commerce7/admin-ui/assets/7304753/37b2cbc1-7d20-46e3-8f4a-033c58206c97)

