### PR TITLE
bring back DisplayIcon export name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.75",
+  "version": "1.11.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.11.75",
+      "version": "1.11.76",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.30.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.75",
+  "version": "1.11.76",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/displayIcon/DisplayIcon.js
+++ b/src/displayIcon/DisplayIcon.js
@@ -6,7 +6,7 @@ import * as Icons from '../icon/icons';
 import { StyledIcon } from './DisplayIcon.styles';
 import IconWrapper from './IconWrapper';
 
-const Display = (props) => {
+const DisplayIcon = (props) => {
   const { className, icon, label, onClick, variant, dataTestId } = props;
 
   const IconComponent = Icons[icon];
@@ -45,7 +45,7 @@ const Display = (props) => {
   );
 };
 
-Display.defaultProps = {
+DisplayIcon.defaultProps = {
   className: null,
   label: null,
   onClick: null,
@@ -53,7 +53,7 @@ Display.defaultProps = {
   dataTestId: null
 };
 
-Display.propTypes = {
+DisplayIcon.propTypes = {
   /**
    * Add className to the outermost element.
    */
@@ -86,4 +86,4 @@ Display.propTypes = {
   dataTestId: PropTypes.string
 };
 
-export default Display;
+export default DisplayIcon;

--- a/src/displayIcon/index.js
+++ b/src/displayIcon/index.js
@@ -1,3 +1,3 @@
-import Display from './DisplayIcon';
+import DisplayIcon from './DisplayIcon';
 
-export default Display;
+export default DisplayIcon;

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import Columns from './columns';
 import ContextMenu from './contextMenu';
 import DataDisplay from './dataDisplay';
 import DatePicker from './datePicker';
-import Display from './displayIcon';
+import DisplayIcon from './displayIcon';
 import Heading from './heading';
 import Icon from './icon';
 import InfoCard from './infoCard';
@@ -60,7 +60,7 @@ export {
   Heading,
   Icon,
   InfoCard,
-  Display,
+  DisplayIcon,
   VividIcon,
   Input,
   LineBreak,

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -8,6 +8,10 @@ import { Meta } from '@storybook/blocks';
 
 #### 1.11.76
 
+- Renamed Display export name to DisplayIcon
+
+#### 1.11.75
+
 - Updated minor NPM packages.
 
 #### 1.11.74


### PR DESCRIPTION
@NoahThomlison 

I revert the icon name from Display to DisplayIcon. This was causing Admin repo crashing because we are using DisplayIcon name in admin so I just revert back to DisplayIcon. Once this PR is merged I will update packages in admin repo