### PR TITLE
add marginBottom prop to override heading component margin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.85",
+  "version": "1.11.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.11.85",
+      "version": "1.11.86",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.30.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.85",
+  "version": "1.11.86",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/heading/Heading.js
+++ b/src/heading/Heading.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { StyledHeading } from './Heading.styles';
 
 const Heading = (props) => {
-  const { children, level, className, dataTestId } = props;
+  const { children, level, marginBottom, className, dataTestId } = props;
 
   let as = 'h2';
   if (level === 1) as = 'h1';
@@ -11,7 +11,12 @@ const Heading = (props) => {
   else if (level === 4) as = 'h4';
 
   return (
-    <StyledHeading as={as} className={className} data-testid={dataTestId}>
+    <StyledHeading
+      as={as}
+      customMarginBottom={marginBottom}
+      className={className}
+      data-testid={dataTestId}
+    >
       {children}
     </StyledHeading>
   );
@@ -19,6 +24,7 @@ const Heading = (props) => {
 
 Heading.defaultProps = {
   level: 2,
+  marginBottom: null,
   className: null,
   dataTestId: null
 };
@@ -28,6 +34,11 @@ Heading.propTypes = {
    * Select what size heading.
    */
   level: PropTypes.oneOf([1, 2, 3, 4]),
+
+  /**
+   * The prop to add custom margin bottom.
+   */
+  marginBottom: PropTypes.string,
 
   /**
    * The content of the component.

--- a/src/heading/Heading.stories.js
+++ b/src/heading/Heading.stories.js
@@ -1,22 +1,34 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import Heading from '.';
 
-export const Basic = () => (
+export const Basic = (args) => (
   <>
-    <Heading level={1}>Heading 1</Heading>
-    <Heading level={2}>Heading 2</Heading>
-    <Heading level={3}>Heading 3</Heading>
-    <Heading level={4}>Heading 4</Heading>
+    <Heading level={1} {...args}>
+      Heading 1
+    </Heading>
+    <Heading level={2} {...args}>
+      Heading 2
+    </Heading>
+    <Heading level={3} {...args}>
+      Heading 3
+    </Heading>
+    <Heading level={4} {...args}>
+      Heading 4
+    </Heading>
   </>
 );
 
-Basic.story = {
-  name: 'Basic'
-};
+export const WithCustomMarginBottom = (args) => (
+  <Heading level={4} marginBottom="5px" {...args}>
+    Heading 4 with Custom Margin Bottom
+  </Heading>
+);
 
 export default {
   title: 'Typography/Heading',
   component: Heading,
   parameters: {
+    controls: { expanded: true },
     docs: {
       description: {
         component: "import { Heading } from '@commerce7/admin-ui'"

--- a/src/heading/Heading.styles.js
+++ b/src/heading/Heading.styles.js
@@ -8,7 +8,8 @@ const StyledHeading = styled.h2`
   color: ${({ theme }) => colors[theme.c7__ui.mode].fontColor};
 
   transition: color 0.3s ease-in-out;
-  margin: 0 0 ${({ as }) => marginBottom[as]} 0;
+  margin: 0 0
+    ${({ as, customMarginBottom }) => customMarginBottom || marginBottom[as]} 0;
   font-size: ${({ as }) => fontSize[as]};
   line-height: 1.4;
   letter-spacing: -0.2px;

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
-#### 1.11.85
+#### 1.11.86
 
 - Added `marginBottom` props to `Heading` component.
 

--- a/src/stories/Releases.stories.mdx
+++ b/src/stories/Releases.stories.mdx
@@ -8,6 +8,10 @@ import { Meta } from '@storybook/blocks';
 
 #### 1.11.85
 
+- Added `marginBottom` props to `Heading` component.
+
+#### 1.11.85
+
 - Updated minor NPM packages.
 
 #### 1.11.84


### PR DESCRIPTION
@JakeHildy 

Andrea would like to add margin prop to Heading. Because currently we are usually override Heading marginBottom always to make it 5px. So this pr will add new prop to Heading component so that we can override marginBottom.

I have one ticket in admin to cleanup all custom style for margin-bottom to replace with this prop
<img width="1317" alt="Screenshot 2024-02-20 at 1 30 15 PM" src="https://github.com/Commerce7/admin-ui/assets/20227401/df5a7ec9-5d2f-40d5-8527-a17d6a2d8db0">
