### PR TITLE
add loading prop to show loading spinner for link button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.96",
+  "version": "1.11.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.11.96",
+      "version": "1.11.97",
       "license": "MIT",
       "dependencies": {
         "@storybook/addon-styling-webpack": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.11.96",
+  "version": "1.11.97",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/linkButton/LinkButton.js
+++ b/src/linkButton/LinkButton.js
@@ -1,7 +1,12 @@
 import PropTypes from 'prop-types';
 import { forwardRef } from 'react';
 
-import { StyledButton, StyledButtonIcon } from '../button/Button.styles';
+import {
+  StyledButton,
+  StyledButtonIcon,
+  StyledButtonText,
+  StyledLoadingIcon
+} from '../button/Button.styles';
 
 const LinkButton = forwardRef((props, ref) => {
   const {
@@ -10,6 +15,7 @@ const LinkButton = forwardRef((props, ref) => {
     component,
     disabled,
     download,
+    loading,
     href,
     rel,
     startIcon,
@@ -31,10 +37,10 @@ const LinkButton = forwardRef((props, ref) => {
 
   return (
     <StyledButton
-      as={disabled ? null : as}
+      as={disabled || loading ? null : as}
       ref={ref}
       className={className}
-      disabled={disabled}
+      disabled={disabled || loading}
       href={href}
       target={target}
       rel={rel}
@@ -44,23 +50,28 @@ const LinkButton = forwardRef((props, ref) => {
       data-testid={dataTestId}
       {...customComponentProps} // eslint-disable-line
     >
-      {startIcon && (
-        <StyledButtonIcon
-          buttonVariant={variant}
-          icon={startIcon}
-          position="start"
-          hasChildren={children !== null}
-        />
-      )}
-      {children}
-      {endIcon && (
-        <StyledButtonIcon
-          buttonVariant={variant}
-          icon={endIcon}
-          position="end"
-          hasChildren={children !== null}
-        />
-      )}
+      <StyledButtonText isLoading={loading}>
+        {startIcon && (
+          <StyledButtonIcon
+            buttonVariant={variant}
+            icon={startIcon}
+            position="start"
+            isHidden={loading}
+            hasChildren={children !== null}
+          />
+        )}
+        {loading && <StyledLoadingIcon icon="loading" />}
+        {children}
+        {endIcon && (
+          <StyledButtonIcon
+            buttonVariant={variant}
+            icon={endIcon}
+            position="end"
+            isHidden={loading}
+            hasChildren={children !== null}
+          />
+        )}
+      </StyledButtonText>
     </StyledButton>
   );
 });
@@ -71,6 +82,7 @@ LinkButton.defaultProps = {
   component: null,
   disabled: false,
   download: null,
+  loading: false,
   href: null,
   rel: null,
   startIcon: null,
@@ -107,6 +119,12 @@ LinkButton.propTypes = {
    * Add download to the dom element
    */
   download: PropTypes.bool,
+
+  /**
+   * Set the button to visually show a loading spinner.
+   * This will also disable the button.
+   */
+  loading: PropTypes.bool,
 
   /**
    * The url to link to.

--- a/src/linkButton/LinkButton.stories.js
+++ b/src/linkButton/LinkButton.stories.js
@@ -66,6 +66,23 @@ export const Disabled = () => (
   </StyledContainer>
 );
 
+export const Loading = () => (
+  <StyledContainer>
+    <LinkButton variant="primary" loading>
+      Primary Button
+    </LinkButton>
+    <LinkButton variant="secondary" loading>
+      Secondary Button
+    </LinkButton>
+    <LinkButton variant="text" loading>
+      Text Button
+    </LinkButton>
+    <LinkButton variant="link" loading>
+      Link Button
+    </LinkButton>
+  </StyledContainer>
+);
+
 export const Size = () => (
   <StyledContainer>
     <LinkButton size="small" href="https://commerce7.com">

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.11.97
+
+- Add `loading` props to `LinkButton` to show loadin spinner.
+
 #### 1.11.96
 
 - Updated major package update for Style loader.


### PR DESCRIPTION
@NoahThomlison @andreadyck 

We would like to show loading status for Apple pay project for Link Button. This `loading` prop will show loading spinner for link button.

![image](https://github.com/Commerce7/admin-ui/assets/20227401/8d29f262-6198-40d6-abf5-ef83a32eb1cd)
