### PR TITLE
update color codes and add new ones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "license": "MIT",
       "dependencies": {
         "@storybook/addon-styling-webpack": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.12.2
+
+- Add and update `c7Colors` platte.
+
 #### 1.12.1
 
 - Updated minor NPM packages.

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -8,7 +8,7 @@ import { Meta } from '@storybook/blocks';
 
 #### 1.12.2
 
-- Add and update `c7Colors` platte.
+- Add and update `c7Colors` palette.
 
 #### 1.12.1
 

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -32,19 +32,21 @@ export const c7Colors = {
   blue500: '#0363A6',
   blue600: '#054483',
 
-  slate100: '#414F58',
-  slate200: '#293238',
-  slate300: '#1e252a',
+  slate100: '#292F3D',
+  slate200: '#1D232F',
+  slate300: '#161C27',
+  slate400: '#121721',
 
-  gray100: '#F8F8F8',
-  gray200: '#F1F1F1',
-  gray300: '#E0E0E0',
-  gray400: '#D1D1D1',
-  gray500: '#989EA4',
-  gray600: '#71767D',
-  gray700: '#585E64',
-  gray800: '#484E54',
-  gray900: '#20272B'
+  gray100: '#F6F7F9',
+  gray200: '#EFF1F4',
+  gray300: '#DDDFE4',
+  gray400: '#CDD0D6',
+  gray500: '#9DA3AE',
+  gray600: '#6B7280',
+  gray700: '#4D5361',
+  gray800: '#343946',
+  gray900: '#2A2E37',
+  gray950: '#26272C'
 };
 
 export const fontColors = {
@@ -63,7 +65,7 @@ const backgroundColors = {
 };
 
 const secondaryBackgroundColors = {
-  dark: c7Colors.gray900,
+  dark: c7Colors.slate400,
   light: c7Colors.gray100
 };
 


### PR DESCRIPTION
@andreadyck This pr is going to update the color plate.

One think I didn't update is that `invertedBackgroundColor`. Because that variable is inside of CardLink component in admin-ui.  (Once this PR is merge I will open Admin PR To update the version)

If you want me to update to slate400, the visual changes will be like this. I liked the other way around but let me know if you wanna do that changes.

Before updating  `invertedBackgroundColor` ;
<img width="500" alt="Screenshot 2024-06-26 at 10 01 11 PM" src="https://github.com/Commerce7/admin-ui/assets/20227401/d77712be-8a73-4b79-a641-ae6960b01b50">

After updating `invertedBackgroundColor` color to slate400;

<img width="500" alt="Screenshot 2024-06-26 at 10 01 21 PM" src="https://github.com/Commerce7/admin-ui/assets/20227401/4f5efa1f-aedf-4706-873d-de17d93a5cf8">
