### PR TITLE
add isOpen props for navbar 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.12.4",
+      "version": "1.12.5",
       "license": "MIT",
       "dependencies": {
         "@storybook/addon-styling-webpack": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/nav/Nav.js
+++ b/src/nav/Nav.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import { NavStyles } from './Nav.styles';
 
 const Nav = (props) => {
-  const { children, dataTestId, className } = props;
+  const { children, dataTestId, className, isOpen } = props;
   return (
-    <NavStyles className={className} data-testid={dataTestId}>
+    <NavStyles className={className} data-testid={dataTestId} isOpen={isOpen}>
       {children}
     </NavStyles>
   );
@@ -14,7 +14,8 @@ const Nav = (props) => {
 Nav.defaultProps = {
   children: null,
   dataTestId: null,
-  className: null
+  className: null,
+  isOpen: true
 };
 
 Nav.propTypes = {
@@ -27,6 +28,11 @@ Nav.propTypes = {
    * Add className to the outermost element
    */
   className: PropTypes.string,
+
+  /**
+   * Open or close Navigation menu
+   */
+  isOpen: PropTypes.bool,
 
   /**
    * Add test attribute to the element. Used internally for testing.

--- a/src/nav/Nav.stories.js
+++ b/src/nav/Nav.stories.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import { useState } from 'react';
+import styled from 'styled-components';
 
 import Nav from '.';
 
@@ -9,7 +10,7 @@ export const Basic = (args) => {
   const [currentPath, setPath] = useState('/dashboard');
 
   return (
-    <Nav {...args}>
+    <StyledNav {...args}>
       <NavLink
         onClick={() => setPath('/dashboard')}
         className={currentPath === '/dashboard' ? 'active' : ''}
@@ -38,7 +39,7 @@ export const Basic = (args) => {
       >
         Club
       </NavLink>
-    </Nav>
+    </StyledNav>
   );
 };
 
@@ -46,7 +47,7 @@ export const SubNavigation = () => {
   const [currentPath, setPath] = useState('/store/order');
 
   return (
-    <Nav>
+    <StyledNav>
       <NavLink
         onClick={() => setPath('/dashboard')}
         className={currentPath === '/dashboard' ? 'active' : ''}
@@ -117,12 +118,16 @@ export const SubNavigation = () => {
           Packages
         </SubNavLink>
       </SubNav>
-    </Nav>
+    </StyledNav>
   );
 };
 
 const description =
   "import { Nav } from '@commerce7/admin-ui'<br/><br/>const { SubNav, NavLink, SubNavLink } = Nav";
+
+const StyledNav = styled(Nav)`
+  height: 50vh;
+`;
 
 export default {
   title: 'Navigation/Nav',

--- a/src/nav/Nav.stories.js
+++ b/src/nav/Nav.stories.js
@@ -1,14 +1,15 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import { useState } from 'react';
 
 import Nav from '.';
 
 const { NavLink, SubNav, SubNavLink } = Nav;
 
-export const Basic = () => {
+export const Basic = (args) => {
   const [currentPath, setPath] = useState('/dashboard');
 
   return (
-    <Nav>
+    <Nav {...args}>
       <NavLink
         onClick={() => setPath('/dashboard')}
         className={currentPath === '/dashboard' ? 'active' : ''}
@@ -39,10 +40,6 @@ export const Basic = () => {
       </NavLink>
     </Nav>
   );
-};
-
-Basic.story = {
-  name: 'Basic'
 };
 
 export const SubNavigation = () => {
@@ -124,10 +121,6 @@ export const SubNavigation = () => {
   );
 };
 
-SubNavigation.story = {
-  name: 'Sub Navigation'
-};
-
 const description =
   "import { Nav } from '@commerce7/admin-ui'<br/><br/>const { SubNav, NavLink, SubNavLink } = Nav";
 
@@ -136,6 +129,7 @@ export default {
   component: Nav,
   subcomponents: { SubNav, NavLink, SubNavLink },
   parameters: {
+    controls: { expand: true },
     docs: {
       description: {
         component: description

--- a/src/nav/Nav.styles.js
+++ b/src/nav/Nav.styles.js
@@ -113,6 +113,7 @@ const SubNavStyles = styled.div`
 const NavStyles = styled.nav`
   background: ${({ theme }) => colors[theme.c7__ui.mode].backgroundColor};
   width: 260px;
+  height: 100vh;
   padding: 10px 10px 5px 10px;
   z-index: 1000;
   overflow: auto;

--- a/src/nav/Nav.styles.js
+++ b/src/nav/Nav.styles.js
@@ -120,6 +120,13 @@ const NavStyles = styled.nav`
     ${({ theme }) => colors[theme.c7__ui.mode].borderColor};
   display: flex;
   flex-direction: column;
+  transition:
+    left 0.5s ease-in-out,
+    background 0.3s ease-in-out,
+    border 0.3s ease-in-out,
+    visibility 0.5s ease-in-out;
+  left: ${({ isOpen }) => (isOpen ? '0px' : '-260px')};
+  visibility: ${({ isOpen }) => (isOpen ? 'visible' : 'hidden')};
 `;
 
 export {

--- a/src/nav/theme.js
+++ b/src/nav/theme.js
@@ -36,7 +36,7 @@ const colors = {
     }
   },
   dark: {
-    backgroundColor: c7Colors.slate200,
+    backgroundColor: c7Colors.slate400,
     borderColor: c7Colors.gray800,
     primaryLink: {
       fontColor: {

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -6,6 +6,11 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+
+#### 1.12.5
+
+- Add `isOpen` props to `Nav` and `update styling.
+
 #### 1.12.4
 
 - Add new colors to `c7Colors` palette and update `VividIcon` colors for light and dark mode.


### PR DESCRIPTION
@andreadyck @NoahThomlison 
Currently our admin repo creating by sideBar by using custom CSS instead of consuming from admin-ui Nav component.

We need isOpen props in admin-ui so that we can consume to close/open for mobile version as well.
This does not effect current component because the default props is true 