### PR TITLE
refactor modalContent to accept disable props for React lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.12",
+  "version": "1.12.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.12.12",
+      "version": "1.12.13",
       "license": "MIT",
       "dependencies": {
         "@storybook/addon-styling-webpack": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.12",
+  "version": "1.12.13",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/modal/ModalContent.js
+++ b/src/modal/ModalContent.js
@@ -47,30 +47,8 @@ const ModalContent = (props) => {
     }
   };
 
-  if (disableFocusLock) {
-    return ReactDom.createPortal(
-      <StyledModalBackground
-        onClick={handleBackgroundClick}
-        className={className}
-      >
-        <StyledModalContent data-testid={dataTestId}>
-          {title && (
-            <StyledModalHeader>
-              <StyledModalTitle>{title}</StyledModalTitle>
-              {onClose && (
-                <Icon icon="close" onClick={handleClose} label="Close modal" />
-              )}
-            </StyledModalHeader>
-          )}
-          {children}
-        </StyledModalContent>
-      </StyledModalBackground>,
-      document.body
-    );
-  }
-
   return ReactDom.createPortal(
-    <FocusLock autoFocus={false}>
+    <FocusLock autoFocus={false} disabled={disableFocusLock}>
       <StyledModalBackground
         onClick={handleBackgroundClick}
         className={className}

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.12.13
+
+- Add `disabled` props to `<ReactLock>` component in `ModalContent`.
+
 #### 1.12.12
 
 - Updated minor NPM packages.


### PR DESCRIPTION
@NoahThomlison @jasonandres @joshclysdale 
This can go on later. This is just refactoring that I realized we can pass disabled props to react focus lock library to disable. No need for additional if conditions.

Better to test after admin pr is merged;
https://github.com/Commerce7/admin/pull/7471