### PR TITLE
fix progress bar overflow issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.20",
+  "version": "1.12.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.12.20",
+      "version": "1.12.22",
       "license": "MIT",
       "dependencies": {
         "@storybook/addon-styling-webpack": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.21",
+  "version": "1.12.22",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/progressBar/ProgressBar.styles.js
+++ b/src/progressBar/ProgressBar.styles.js
@@ -13,7 +13,8 @@ const StyledProgressBarWrapper = styled.div`
 `;
 
 const StyledProgressBar = styled.div`
-  width: ${({ progress }) => `${progress}%`};
+  width: ${({ progress }) =>
+    `${Math.min(progress, 100)}%`}; /* Cap width at 100% */
   height: 100%;
   animation: progressAnimation 1s ease-in-out;
   background: ${({ color }) => `${color}`};

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -6,6 +6,11 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.12.22
+
+- Minor bug fixes.
+
+
 #### 1.12.21
 
 - Add icons: `code`, `form`, `screen`


### PR DESCRIPTION
@yves-matta @NoahThomlison @andreadyck 

This is going to cap at %100 width for progress bar even if customer has over 100 percentage.

After this merge I will add admin PR as well.

After fix
![image](https://github.com/user-attachments/assets/504d553c-b371-4edf-a773-805e627a5215)
