### PR TITLE
update card component styles to match with design system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.25",
+  "version": "1.12.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.12.25",
+      "version": "1.12.26",
       "license": "MIT",
       "dependencies": {
         "@storybook/addon-styling-webpack": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.25",
+  "version": "1.12.26",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/infoCard/InfoCard.styles.js
+++ b/src/infoCard/InfoCard.styles.js
@@ -51,7 +51,6 @@ const StyledLabel = styled.span`
   color: rgba(0, 0, 0, 0.4);
   font-weight: ${({ theme }) => theme.c7__ui.fontWeightBase};
   font-size: ${({ theme }) => theme.c7__ui.fontSizeBase};
-  text-transform: uppercase;
   margin-bottom: 10px;
   display: block;
   ${({ theme, variant }) => `

--- a/src/infoCard/InfoCard.styles.js
+++ b/src/infoCard/InfoCard.styles.js
@@ -49,8 +49,8 @@ const StyledIcon = styled.div`
 
 const StyledLabel = styled.span`
   color: rgba(0, 0, 0, 0.4);
-  font-size: 13px;
-  font-weight: 700;
+  font-weight: ${({ theme }) => theme.c7__ui.fontWeightBase};
+  font-size: ${({ theme }) => theme.c7__ui.fontSizeBase};
   text-transform: uppercase;
   margin-bottom: 10px;
   display: block;
@@ -60,8 +60,8 @@ const StyledLabel = styled.span`
 `;
 
 const StyledTitle = styled.span`
-  font-size: 18px;
-  font-weight: 400;
+  font-size: 20px;
+  font-weight: ${({ theme }) => theme.c7__ui.fontWeightBase};
   display: block;
   margin-bottom: 5px;
   ${({ theme, variant }) => `
@@ -75,7 +75,7 @@ const StyledTitle = styled.span`
 
 const StyledSubtitle = styled(Text)`
   ${({ theme, variant }) => `
-    color: ${colors[theme.c7__ui.mode].fontColor[variant]};
+    color: ${colors[theme.c7__ui.mode].secondaryFontColor[variant]};
   `}
 `;
 

--- a/src/infoCard/theme.js
+++ b/src/infoCard/theme.js
@@ -43,6 +43,13 @@ const colors = {
       error: c7Colors.white,
       warning: c7Colors.slate300,
       success: c7Colors.white
+    },
+    secondaryFontColor: {
+      default: c7Colors.gray600,
+      info: c7Colors.white,
+      error: c7Colors.white,
+      warning: c7Colors.slate300,
+      success: c7Colors.white
     }
   },
   dark: {
@@ -83,6 +90,13 @@ const colors = {
     },
     fontColor: {
       default: c7Colors.white,
+      info: c7Colors.white,
+      error: c7Colors.white,
+      warning: c7Colors.slate300,
+      success: c7Colors.white
+    },
+    secondaryFontColor: {
+      default: c7Colors.gray500,
       info: c7Colors.white,
       error: c7Colors.white,
       warning: c7Colors.slate300,

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.12.26
+
+- Update `InfoCard` component to use standard font sizes and weights.
+
 #### 1.12.25
 
 - Major NPM packages.


### PR DESCRIPTION
@andreadyck This is the work we need to use the theme styles for InfoCard. once this merges, will update admin to use latest package

For secondary color; I created `secondaryFontColor` because we have different theme file for Info card and works based of variants.

The sketch design has lower-case for title but we currently use upper case in admin, let me know I can remove `text-transform` in admin-ui if you want.

After admin uses new version ;
<img width="700" alt="image" src="https://github.com/user-attachments/assets/3a2d3d4f-4635-4ebe-bf25-408d7de17689" />
<img width="700" alt="image" src="https://github.com/user-attachments/assets/5af68504-de75-40b5-b0c8-2d48da6a97df" />

