### PR TITLE
SC-14794 | Adjust Switch min width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.31",
+  "version": "1.12.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.12.31",
+      "version": "1.12.32",
       "license": "MIT",
       "dependencies": {
         "@storybook/addon-styling-webpack": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.31",
+  "version": "1.12.32",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.12.32
+
+- Update Switch component to have a min-width.
+
 #### 1.12.31
 
 - Minor NPM packages.

--- a/src/switch/Switch.styles.js
+++ b/src/switch/Switch.styles.js
@@ -5,7 +5,7 @@ import { StyledHiddenInput } from '../common/form/styles';
 import { colors } from './theme';
 
 const StyledSwitchIcon = styled.span`
-  width: 32px;
+  min-width: 32px;
   height: 20px;
   position: relative;
   background-color: transparent;


### PR DESCRIPTION
## Current Issue

When the Switch component has a label with a long length, the round/white part of the switch is not aligned. The white part of the switch should always display on top of the blue toggle background

## Current fix

Add minimum width to the switch

## Testing

> Risk Level: Low

Describe how to test it

- [ ] When the Switch component has a label with a long length, the round/white part of the switch is not aligned. The white part of the switch should always display on top of the blue toggle background

## Screenshot

### Before
<img width="278" alt="Screenshot 2025-03-12 at 1 25 16 PM" src="https://github.com/user-attachments/assets/abaac97c-94d1-4be1-8003-fa8b3c37bf1e" />

### After
<img width="269" alt="Screenshot 2025-03-12 at 1 25 26 PM" src="https://github.com/user-attachments/assets/cca13eb4-3131-4a2d-93c1-7e1ca9b60ff8" />
