### PR TITLE
SC-15177 | Update Tabs component padding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.33",
+  "version": "1.12.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.12.33",
+      "version": "1.12.34",
       "license": "MIT",
       "dependencies": {
         "@storybook/addon-styling-webpack": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.33",
+  "version": "1.12.34",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.12.34
+
+- Update Tab component padding from 15px to 10px.
+
 #### 1.12.33
 
 - Minor NPM packages.

--- a/src/tabs/Tabs.styles.js
+++ b/src/tabs/Tabs.styles.js
@@ -26,7 +26,7 @@ const TabStyles = styled.div`
   @media ${({ theme }) => theme.c7__ui.breakpoints.mediumUp} {
     max-width: 225px;
     flex-grow: 0;
-    padding: 0 15px;
+    padding: 0 10px;
   }
 
   ${({ theme, $activeClassName }) => `


### PR DESCRIPTION
## Current Issue

Tabs wrap on some desktop sizes so we want to reduce horizontal padding so that more can fit in a single line
## Current fix

Update Tabs component padding from 15px to 10px

## Testing

> Risk Level: Low

Describe how to test it

- [ ] Make sure the tab component padding is set as expected

## Screenshot

<img width="1999" alt="Screenshot 2025-03-21 at 12 15 41 PM" src="https://github.com/user-attachments/assets/d864f5ce-69ce-4336-856d-213b8706e200" />



