### PR TITLE
update admin ui to allow select button to accept icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.34",
+  "version": "1.12.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.12.34",
+      "version": "1.12.35",
       "license": "MIT",
       "dependencies": {
         "@storybook/addon-styling-webpack": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.34",
+  "version": "1.12.35",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/checkbox/Checkbox.js
+++ b/src/checkbox/Checkbox.js
@@ -73,6 +73,7 @@ const Checkbox = forwardRef((props, ref) => {
               icon={icon}
               disabled={disabled}
               as="span"
+              isButtonVariant
             >
               {children}
             </SelectButton>

--- a/src/radio/Radio.js
+++ b/src/radio/Radio.js
@@ -74,6 +74,7 @@ const Radio = forwardRef((props, ref) => {
             disabled={disabled}
             onClick={onClick}
             as="span"
+            isButtonVariant
           >
             {children}
           </SelectButton>

--- a/src/selectButton/SelectButton.js
+++ b/src/selectButton/SelectButton.js
@@ -25,11 +25,12 @@ const SelectButton = forwardRef((props, ref) => {
     dataTestId,
     size,
     icon,
-    as
+    as,
+    isButtonVariant
   } = props;
 
   if (size === 'small') {
-    if (!children && icon) {
+    if (isButtonVariant && icon) {
       return (
         <StyledSmallIconSelectButton
           ref={ref}
@@ -139,7 +140,8 @@ SelectButton.defaultProps = {
   dataTestId: null,
   size: 'large',
   icon: null,
-  children: null
+  children: null,
+  isButtonVariant: false
 };
 
 SelectButton.propTypes = {
@@ -164,6 +166,11 @@ SelectButton.propTypes = {
    * This prop is intended to be used during asynchronous actions, like submitting a form.
    */
   loading: PropTypes.bool,
+
+  /**
+   * This will make the button the isButtonVariant if an icon is also passed in.
+   */
+  isButtonVariant: PropTypes.bool,
 
   /**
    * Set the button to visually show that its selected.

--- a/src/selectButton/SelectButton.js
+++ b/src/selectButton/SelectButton.js
@@ -7,7 +7,10 @@ import {
   StyledSelectButton,
   StyledLoadingIcon,
   StyledSmallSelectButton,
-  StyledMediumSelectButton
+  StyledMediumSelectButton,
+  StyledButtonContainer,
+  StyledSmallIconSelectButton,
+  StyledChildrenContainer
 } from './SelectButton.styles';
 
 const SelectButton = forwardRef((props, ref) => {
@@ -26,6 +29,29 @@ const SelectButton = forwardRef((props, ref) => {
   } = props;
 
   if (size === 'small') {
+    if (!children && icon) {
+      return (
+        <StyledSmallIconSelectButton
+          ref={ref}
+          className={className}
+          disabled={disabled || loading}
+          type={type}
+          onClick={onClick}
+          selected={selected}
+          data-testid={dataTestId}
+          q
+          hasIcon={!!icon}
+          as={as}
+        >
+          {loading ? (
+            <StyledLoadingIcon icon="loading" />
+          ) : (
+            <Icon icon={icon} />
+          )}
+        </StyledSmallIconSelectButton>
+      );
+    }
+
     return (
       <StyledSmallSelectButton
         ref={ref}
@@ -38,14 +64,16 @@ const SelectButton = forwardRef((props, ref) => {
         hasIcon={!!icon}
         as={as}
       >
-        {loading ? (
-          <StyledLoadingIcon icon="loading" />
-        ) : (
-          <>
-            {icon && <Icon icon={icon} />}
-            {children}
-          </>
-        )}
+        <StyledButtonContainer>
+          {loading ? (
+            <StyledLoadingIcon icon="loading" />
+          ) : (
+            <>
+              {icon && <Icon icon={icon} />}
+              <StyledChildrenContainer>{children}</StyledChildrenContainer>
+            </>
+          )}
+        </StyledButtonContainer>
       </StyledSmallSelectButton>
     );
   }
@@ -62,7 +90,16 @@ const SelectButton = forwardRef((props, ref) => {
         data-testid={dataTestId}
         as={as}
       >
-        {loading ? <StyledLoadingIcon icon="loading" /> : children}
+        <StyledButtonContainer>
+          {loading ? (
+            <StyledLoadingIcon icon="loading" />
+          ) : (
+            <>
+              {icon && <Icon icon={icon} />}
+              <StyledChildrenContainer>{children}</StyledChildrenContainer>
+            </>
+          )}
+        </StyledButtonContainer>
       </StyledMediumSelectButton>
     );
   }
@@ -78,7 +115,16 @@ const SelectButton = forwardRef((props, ref) => {
       data-testid={dataTestId}
       as={as}
     >
-      {loading ? <StyledLoadingIcon icon="loading" /> : children}
+      <StyledButtonContainer>
+        {loading ? (
+          <StyledLoadingIcon icon="loading" />
+        ) : (
+          <>
+            {icon && <Icon icon={icon} />}
+            <StyledChildrenContainer>{children}</StyledChildrenContainer>
+          </>
+        )}
+      </StyledButtonContainer>
     </StyledSelectButton>
   );
 });

--- a/src/selectButton/SelectButton.stories.js
+++ b/src/selectButton/SelectButton.stories.js
@@ -19,10 +19,10 @@ Basic.story = {
 
 export const Icon = () => (
   <Container>
-    <SelectButton size="small" icon="alignLeft" disabled />
-    <SelectButton size="small" icon="alignCenter" selected />
-    <SelectButton size="small" icon="alignRight" loading />
-    <SelectButton size="small" icon="wine" />
+    <SelectButton size="small" icon="alignLeft" disabled isButtonVariant />
+    <SelectButton size="small" icon="alignCenter" selected isButtonVariant />
+    <SelectButton size="small" icon="alignRight" loading isButtonVariant />
+    <SelectButton size="small" icon="wine" isButtonVariant />
   </Container>
 );
 

--- a/src/selectButton/SelectButton.stories.js
+++ b/src/selectButton/SelectButton.stories.js
@@ -17,7 +17,7 @@ Basic.story = {
   name: 'Basic'
 };
 
-export const SmallIcon = () => (
+export const Icon = () => (
   <Container>
     <SelectButton size="small" icon="alignLeft" disabled />
     <SelectButton size="small" icon="alignCenter" selected />
@@ -26,26 +26,72 @@ export const SmallIcon = () => (
   </Container>
 );
 
-SmallIcon.story = {
+Icon.story = {
   name: 'SmallIcon'
 };
 
 export const SmallText = () => (
-  <Container>
-    <SelectButton size="small" disabled>
-      Small
-    </SelectButton>
-    <SelectButton size="small" selected>
-      Medium
-    </SelectButton>
-    <SelectButton size="small" loading>
-      Large
-    </SelectButton>
-  </Container>
+  <>
+    <Container>
+      <SelectButton size="small" disabled>
+        Small
+      </SelectButton>
+      <SelectButton size="small" selected>
+        Medium
+      </SelectButton>
+      <SelectButton size="small" loading>
+        Large
+      </SelectButton>
+    </Container>
+    <br />
+    <Container>
+      <SelectButton size="small" icon="add" disabled>
+        Small
+      </SelectButton>
+      <SelectButton size="small" icon="add" selected>
+        Medium
+      </SelectButton>
+      <SelectButton size="small" icon="add" loading>
+        Large
+      </SelectButton>
+    </Container>
+  </>
 );
 
 SmallText.story = {
   name: 'SmallText'
+};
+
+export const MediumText = () => (
+  <>
+    <Container>
+      <SelectButton size="medium" disabled>
+        Small
+      </SelectButton>
+      <SelectButton size="medium" selected>
+        Medium
+      </SelectButton>
+      <SelectButton size="medium" loading>
+        Large
+      </SelectButton>
+    </Container>
+    <br />
+    <Container>
+      <SelectButton size="medium" icon="add" disabled>
+        Small
+      </SelectButton>
+      <SelectButton size="medium" icon="add" selected>
+        Medium
+      </SelectButton>
+      <SelectButton size="medium" icon="add" loading>
+        Large
+      </SelectButton>
+    </Container>
+  </>
+);
+
+MediumText.story = {
+  name: 'mediumText'
 };
 
 export const SelectMany = () => {
@@ -54,19 +100,50 @@ export const SelectMany = () => {
   const [noTomato, setNoTomato] = useState(false);
 
   return (
-    <Container>
-      <SelectButton selected={cheese} onClick={() => setCheese(!cheese)}>
-        Add Cheese
-        <Text>$1.00</Text>
-      </SelectButton>
-      <SelectButton selected={bacon} onClick={() => setBacon(!bacon)}>
-        Add Bacon
-        <Text>$1.50</Text>
-      </SelectButton>
-      <SelectButton selected={noTomato} onClick={() => setNoTomato(!noTomato)}>
-        No Tomato
-      </SelectButton>
-    </Container>
+    <>
+      <Container>
+        <SelectButton selected={cheese} onClick={() => setCheese(!cheese)}>
+          Add Cheese
+          <Text>$1.00</Text>
+        </SelectButton>
+        <SelectButton selected={bacon} onClick={() => setBacon(!bacon)}>
+          Add Bacon
+          <Text>$1.50</Text>
+        </SelectButton>
+        <SelectButton
+          selected={noTomato}
+          onClick={() => setNoTomato(!noTomato)}
+        >
+          No Tomato
+        </SelectButton>
+      </Container>
+      <br />
+      <Container>
+        <SelectButton
+          icon="add"
+          selected={cheese}
+          onClick={() => setCheese(!cheese)}
+        >
+          Add Cheese
+          <Text>$1.00</Text>
+        </SelectButton>
+        <SelectButton
+          icon="add"
+          selected={bacon}
+          onClick={() => setBacon(!bacon)}
+        >
+          Add Bacon
+          <Text>$1.50</Text>
+        </SelectButton>
+        <SelectButton
+          icon="add"
+          selected={noTomato}
+          onClick={() => setNoTomato(!noTomato)}
+        >
+          No Tomato
+        </SelectButton>
+      </Container>
+    </>
   );
 };
 
@@ -78,50 +155,63 @@ export const SelectOne = () => {
   const [tender, setTender] = useState('visa');
 
   return (
-    <Container>
-      <SelectButton
-        selected={tender === 'visa'}
-        onClick={() => setTender('visa')}
-      >
-        Visa
-        <Text>$58.37</Text>
-      </SelectButton>
-      <SelectButton
-        selected={tender === 'mastercard'}
-        onClick={() => setTender('mastercard')}
-      >
-        Mastercard
-        <Text>$58.37</Text>
-      </SelectButton>
-      <SelectButton
-        selected={tender === 'cash'}
-        onClick={() => setTender('cash')}
-      >
-        Cash
-        <Text>$58.37</Text>
-      </SelectButton>
-    </Container>
+    <>
+      <Container>
+        <SelectButton
+          selected={tender === 'visa'}
+          onClick={() => setTender('visa')}
+        >
+          Visa
+          <Text>$58.37</Text>
+        </SelectButton>
+        <SelectButton
+          selected={tender === 'mastercard'}
+          onClick={() => setTender('mastercard')}
+        >
+          Mastercard
+          <Text>$58.37</Text>
+        </SelectButton>
+        <SelectButton
+          selected={tender === 'cash'}
+          onClick={() => setTender('cash')}
+        >
+          Cash
+          <Text>$58.37</Text>
+        </SelectButton>
+      </Container>
+      <br />
+      <Container>
+        <SelectButton
+          icon="add"
+          selected={tender === 'visa'}
+          onClick={() => setTender('visa')}
+        >
+          Visa
+          <Text>$58.37</Text>
+        </SelectButton>
+        <SelectButton
+          icon="add"
+          selected={tender === 'mastercard'}
+          onClick={() => setTender('mastercard')}
+        >
+          Mastercard
+          <Text>$58.37</Text>
+        </SelectButton>
+        <SelectButton
+          icon="add"
+          selected={tender === 'cash'}
+          onClick={() => setTender('cash')}
+        >
+          Cash
+          <Text>$58.37</Text>
+        </SelectButton>
+      </Container>
+    </>
   );
 };
 
 SelectOne.story = {
   name: 'SelectOne'
-};
-
-export const Medium = () => (
-  <Container>
-    <SelectButton size="medium">Basic</SelectButton>
-    <SelectButton size="medium" loading>
-      Loading
-    </SelectButton>
-    <SelectButton size="medium" disabled>
-      Can&apos;t touch this
-    </SelectButton>
-  </Container>
-);
-
-Medium.story = {
-  name: 'Medium'
 };
 
 const Container = styled.div`

--- a/src/selectButton/SelectButton.styles.js
+++ b/src/selectButton/SelectButton.styles.js
@@ -91,6 +91,16 @@ const StyledSmallSelectButton = styled(StyledSelectButton)`
   padding: 12px;
   border-radius: 2px;
   color: ${({ theme }) => theme.c7__ui.fontColor};
+`;
+
+const StyledSmallIconSelectButton = styled(StyledSelectButton)`
+  min-height: 46px;
+  min-width: 46px;
+  height: 46px;
+  max-height: 46px;
+  padding: 12px;
+  border-radius: 2px;
+  color: ${({ theme }) => theme.c7__ui.fontColor};
 
   ${({ hasIcon }) =>
     hasIcon
@@ -122,9 +132,29 @@ const StyledMediumSelectButton = styled(StyledSelectButton)`
   }
 `;
 
+const StyledButtonContainer = styled.div`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  border: 1px solid transparent;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  gap: 10px;
+`;
+
+const StyledChildrenContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
 export {
   StyledSelectButton,
   StyledLoadingIcon,
   StyledSmallSelectButton,
-  StyledMediumSelectButton
+  StyledSmallIconSelectButton,
+  StyledMediumSelectButton,
+  StyledButtonContainer,
+  StyledChildrenContainer
 };

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -6,6 +6,11 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.12.35
+
+- Updates Select Button to render a icon for small, medium and large sized buttons
+- Adds extra stories showing variants with icons and sizes
+
 #### 1.12.34
 
 - Update Tab component padding from 15px to 10px.


### PR DESCRIPTION
The design of the new customer insights requires the addition of an icon to the select button. 

The issue here is that we previously had a button design for when there is an icon. It does not work well when you add text and a icon. They get stacked vertically instead of horizontally aligned.

Use in main
<img width="536" alt="image" src="https://github.com/user-attachments/assets/cf9f8e07-d994-4a64-a983-b675ef40ddab" />


I have updated it so that if there is a prop passed in called isButtonVariant, then the icon version appears. This allows us to pass in either button Variant or icons + children.

I have renamed what was the small to the Icon and have added icon variants to the small text, medium text, select many and select one stories
https://www.loom.com/share/7b3555b7887b436db30733428261478f
