### PR TITLE
Update select button styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.34",
+  "version": "1.12.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.12.34",
+      "version": "1.12.35",
       "license": "MIT",
       "dependencies": {
         "@storybook/addon-styling-webpack": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.34",
+  "version": "1.12.35",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/selectButton/SelectButton.stories.js
+++ b/src/selectButton/SelectButton.stories.js
@@ -7,9 +7,10 @@ import SelectButton from '.';
 
 export const Basic = () => (
   <Container>
-    <SelectButton>Basic</SelectButton>
+    <SelectButton>Default</SelectButton>
+    <SelectButton selected>Selected</SelectButton>
     <SelectButton loading>Loading</SelectButton>
-    <SelectButton disabled>Can&apos;t touch this</SelectButton>
+    <SelectButton disabled>Disabled</SelectButton>
   </Container>
 );
 
@@ -19,10 +20,10 @@ Basic.story = {
 
 export const SmallIcon = () => (
   <Container>
-    <SelectButton size="small" icon="alignLeft" disabled />
-    <SelectButton size="small" icon="alignCenter" selected />
-    <SelectButton size="small" icon="alignRight" loading />
     <SelectButton size="small" icon="wine" />
+    <SelectButton size="small" icon="tasting" selected />
+    <SelectButton size="small" icon="wine" loading />
+    <SelectButton size="small" icon="product" disabled />
   </Container>
 );
 
@@ -32,14 +33,15 @@ SmallIcon.story = {
 
 export const SmallText = () => (
   <Container>
-    <SelectButton size="small" disabled>
-      Small
-    </SelectButton>
+    <SelectButton size="small">Default</SelectButton>
     <SelectButton size="small" selected>
-      Medium
+      Selected
     </SelectButton>
     <SelectButton size="small" loading>
-      Large
+      Loading
+    </SelectButton>
+    <SelectButton size="small" disabled>
+      Disabled
     </SelectButton>
   </Container>
 );
@@ -110,12 +112,15 @@ SelectOne.story = {
 
 export const Medium = () => (
   <Container>
-    <SelectButton size="medium">Basic</SelectButton>
+    <SelectButton size="medium">Default</SelectButton>
+    <SelectButton size="medium" selected>
+      Selected
+    </SelectButton>
     <SelectButton size="medium" loading>
       Loading
     </SelectButton>
     <SelectButton size="medium" disabled>
-      Can&apos;t touch this
+      Disabled
     </SelectButton>
   </Container>
 );

--- a/src/selectButton/SelectButton.styles.js
+++ b/src/selectButton/SelectButton.styles.js
@@ -10,6 +10,7 @@ const StyledSelectButton = styled.button`
   justify-content: center;
   flex: 1;
   flex-direction: column;
+  gap: 3px;
 
   cursor: pointer;
   transition: background-color 0.3s ease-in-out;
@@ -19,8 +20,8 @@ const StyledSelectButton = styled.button`
   border-width: ${({ selected }) => (selected ? '2px' : '1px')};
   border-color: ${({ theme, selected }) =>
     selected
-      ? colors[theme.c7__ui.mode].borderColor.default
-      : theme.c7__ui.borderColor};
+      ? colors[theme.c7__ui.mode].borderColor.focus
+      : colors[theme.c7__ui.mode].borderColor.default};
   border-radius: ${({ theme }) => theme.c7__ui.borderRadius};
 
   background-color: ${({ theme }) =>
@@ -34,7 +35,6 @@ const StyledSelectButton = styled.button`
   white-space: break-spaces;
   color: ${({ theme }) => colors[theme.c7__ui.mode].fontColor.default};
   font-weight: 400;
-  font-size: 16px;
   font-family: ${({ theme }) => theme.c7__ui.fontFamily};
 
   &:focus:not(:disabled) {
@@ -64,6 +64,11 @@ const StyledSelectButton = styled.button`
     * {
       color: ${({ theme }) => colors[theme.c7__ui.mode].fontColor.disabled};
     }
+    ${Icon} {
+      path {
+        fill: ${({ theme }) => colors[theme.c7__ui.mode].fontColor.disabled};
+      }
+    }
   }
 `;
 
@@ -90,7 +95,7 @@ const StyledSmallSelectButton = styled(StyledSelectButton)`
   max-height: 46px;
   padding: 12px;
   border-radius: 2px;
-  color: ${({ theme }) => theme.c7__ui.fontColor};
+  color: ${({ theme }) => colors[theme.c7__ui.mode].fontColor.defaultSmall};
 
   ${({ hasIcon }) =>
     hasIcon
@@ -102,7 +107,7 @@ const StyledSmallSelectButton = styled(StyledSelectButton)`
 
   ${Icon} {
     path {
-      fill: ${({ theme }) => theme.c7__ui.fontColor};
+      fill: ${({ theme }) => colors[theme.c7__ui.mode].fontColor.defaultSmall};
     }
   }
 `;

--- a/src/selectButton/theme.js
+++ b/src/selectButton/theme.js
@@ -3,10 +3,10 @@ import { c7Colors } from '../ui/theme';
 const colors = {
   dark: {
     borderColor: {
-      default: c7Colors.blue500,
-      hover: c7Colors.blue300,
-      focus: c7Colors.blue300,
-      disabled: c7Colors.gray500
+      default: c7Colors.gray600,
+      hover: c7Colors.blue400,
+      focus: c7Colors.blue400,
+      disabled: c7Colors.gray800
     },
     backgroundColor: {
       default: c7Colors.slate300,
@@ -15,26 +15,28 @@ const colors = {
       disabled: c7Colors.slate300
     },
     fontColor: {
+      defaultSmall: c7Colors.gray200,
       default: c7Colors.blue400,
-      hover: c7Colors.blue300,
-      focus: c7Colors.blue300,
-      disabled: c7Colors.gray500
+      hover: c7Colors.blue400,
+      focus: c7Colors.blue400,
+      disabled: c7Colors.gray600
     }
   },
   light: {
     borderColor: {
-      default: c7Colors.blue400,
+      default: c7Colors.gray400,
       hover: c7Colors.blue400,
       focus: c7Colors.blue400,
-      disabled: c7Colors.gray500
+      disabled: c7Colors.gray300
     },
     backgroundColor: {
       default: c7Colors.white,
-      hover: c7Colors.gray300,
-      focus: c7Colors.gray300,
+      hover: c7Colors.gray200,
+      focus: c7Colors.gray200,
       disabled: c7Colors.white
     },
     fontColor: {
+      defaultSmall: c7Colors.slate300,
       default: c7Colors.blue500,
       hover: c7Colors.blue500,
       focus: c7Colors.blue500,

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.12.35
+
+- Update `SelectButton` border color for default and disabled states
+
 #### 1.12.34
 
 - Update Tab component padding from 15px to 10px.


### PR DESCRIPTION
**This one isn't a priority to get in.**

## Current Issue
- Select buttons weren't using all of the set colours (some referenced the general theme instead)
- Border colours for default and disabled buttons didn't match other field and button styles

## Current Fix
- Update select buttons to use the theme colours
- Update colours for borders to match other fields and buttons
- Update the stories example page to have 1 example per button type: Default, Selected, Loading, Disabled

### Light mode
#### Before

![Screenshot 2025-03-25 at 3 12 12 PM](https://github.com/user-attachments/assets/346674b8-d9ee-4ac4-9333-4f5e31be3e0e)

![Screenshot 2025-03-25 at 3 13 43 PM](https://github.com/user-attachments/assets/19a64dd9-ff0e-46fd-abd9-283607d79dfa)
![Screenshot 2025-03-25 at 3 15 15 PM](https://github.com/user-attachments/assets/3ed392f8-e85f-4124-9051-10c5b46ae80a)
![Screenshot 2025-03-25 at 3 12 39 PM](https://github.com/user-attachments/assets/a7fc2f82-f43b-46e9-9c74-fb23fb8f3959)

#### After

![Screenshot 2025-03-25 at 3 12 20 PM](https://github.com/user-attachments/assets/eb8aa6f3-ea45-415d-beab-51040c4f62fc)

![Screenshot 2025-03-25 at 3 13 49 PM](https://github.com/user-attachments/assets/45c503d0-a0ea-4615-a9a6-6f21d4fce097)
![Screenshot 2025-03-25 at 3 15 22 PM](https://github.com/user-attachments/assets/4a20a186-77fa-4c2b-b1c2-78ef1af9b93c)
![Screenshot 2025-03-25 at 3 12 52 PM](https://github.com/user-attachments/assets/94c46323-cdf5-4755-aa0c-cbb1859beae0)

### Dark mode
#### Before

![Screenshot 2025-03-25 at 3 12 17 PM](https://github.com/user-attachments/assets/c45224c4-7627-4bb4-a702-e3d0066f5aef)

![Screenshot 2025-03-25 at 3 13 46 PM](https://github.com/user-attachments/assets/d3673dea-932d-422c-98f3-dea5bee0f081)
![Screenshot 2025-03-25 at 3 15 18 PM](https://github.com/user-attachments/assets/f0ceec7f-ca16-4297-8d0a-c15fc40705b0)
![Screenshot 2025-03-25 at 3 12 42 PM](https://github.com/user-attachments/assets/6fe9402a-c97b-496d-9274-3b7c177b5947)

#### After

![Screenshot 2025-03-25 at 3 12 23 PM](https://github.com/user-attachments/assets/f9b33b49-6eeb-4c6b-a3d7-c74ac61c317d)

![Screenshot 2025-03-25 at 3 13 52 PM](https://github.com/user-attachments/assets/f925dd16-0420-4e58-a480-578b5910306a)
![Screenshot 2025-03-25 at 3 15 25 PM](https://github.com/user-attachments/assets/23c3b310-4f64-4beb-ba68-df545ca9f512)
![Screenshot 2025-03-25 at 3 12 56 PM](https://github.com/user-attachments/assets/d97b8341-cec3-41e9-83f2-9d135bb236a8)

