### PR TITLE
SC-15228 | Update tag component to wrap text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.37",
+  "version": "1.12.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "1.12.37",
+      "version": "1.12.38",
       "license": "MIT",
       "dependencies": {
         "@storybook/addon-styling-webpack": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "1.12.37",
+  "version": "1.12.38",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -6,9 +6,13 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 1.12.38
+
+- Update `Tag` by removing the "white-space: nowrap" so the text can wrap.
+
 #### 1.12.37
 
-- Update `NoRecords` to add the iconVariant prop
+- Update `NoRecords` to add the iconVariant prop.
 
 #### 1.12.36
 
@@ -18,7 +22,7 @@ import { Meta } from '@storybook/blocks';
 
 #### 1.12.35
 
-- Update `SelectButton` border color for default and disabled states
+- Update `SelectButton` border color for default and disabled states.
 
 #### 1.12.34
 

--- a/src/tag/Tag.styles.js
+++ b/src/tag/Tag.styles.js
@@ -47,7 +47,6 @@ const StyledTagLabel = styled.span`
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
-  padding 5px;
 `;
 
 const StyledDeleteButton = styled.button`

--- a/src/tag/Tag.styles.js
+++ b/src/tag/Tag.styles.js
@@ -47,7 +47,7 @@ const StyledTagLabel = styled.span`
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  padding 5px;
 `;
 
 const StyledDeleteButton = styled.button`


### PR DESCRIPTION
## Current Issue

When the search component is used in a modal, items with longer titles are cut off which decreases the usability.

This was reported by a client for Reporting > Queries specifically, but could be an issue anywhere the field is used in a modal.

## Current fix

Wrap tag text

## Testing

> Risk Level: Low 

Describe how to test it

- [ ] Make sure the tag text wraps when we have limited space, like inside a modal

## Screenshots

<img width="926" alt="Screenshot 2025-04-02 at 9 36 28 AM" src="https://github.com/user-attachments/assets/2fbc0857-3194-4ec5-adfe-137a6254f504" />


