### PR TITLE
SC-16037 | FEAT -  Update React to 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",
@@ -21,7 +21,6 @@
         "eslint-plugin-cypress": "^5.0.1",
         "eslint-plugin-no-only-tests": "^3.3.0",
         "moment": "^2.30.1",
-        "prop-types": "^15.8.1",
         "react-datetime": "^3.3.1",
         "react-focus-lock": "^2.13.6",
         "recharts": "^2.15.3",
@@ -73,8 +72,8 @@
         "lint-staged": "^15.5.2",
         "path": "^0.12.7",
         "prettier": "^3.5.3",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
         "storybook": "^8.6.14",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.5.2",
@@ -83,8 +82,8 @@
         "webpack-cli": "^6.0.1"
       },
       "peerDependencies": {
-        "react": "^18.1.0-0",
-        "react-dom": "^18.1.0-0",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
         "styled-components": "^5.3.11",
         "styled-normalize": "^8.1.1"
       }
@@ -12773,14 +12772,11 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12843,17 +12839,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.1.0"
       }
     },
     "node_modules/react-focus-lock": {
@@ -13558,14 +13553,11 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"
@@ -65,8 +65,8 @@
     "lint-staged": "^15.5.2",
     "path": "^0.12.7",
     "prettier": "^3.5.3",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "storybook": "^8.6.14",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.5.2",
@@ -75,29 +75,28 @@
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
-    "@commerce7/eslint-config": "^2.0.0-beta.8",
-    "webpack-node-externals": "^3.0.0",
-    "@storybook/theming": "^8.3.6",
-    "clean-webpack-plugin": "^4.0.0",
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.1",
-    "eslint-plugin-no-only-tests": "^3.3.0",
-    "eslint-plugin-cypress": "^5.0.1",
+    "@commerce7/eslint-config": "^2.0.0-beta.8",
     "@storybook/addon-styling-webpack": "^1.0.1",
     "@storybook/manager-api": "^8.3.6",
     "@storybook/preview-api": "^8.3.6",
+    "@storybook/theming": "^8.3.6",
     "ajv": "^8.17.1",
+    "clean-webpack-plugin": "^4.0.0",
+    "eslint-plugin-cypress": "^5.0.1",
+    "eslint-plugin-no-only-tests": "^3.3.0",
     "moment": "^2.30.1",
-    "prop-types": "^15.8.1",
     "react-datetime": "^3.3.1",
     "react-focus-lock": "^2.13.6",
     "recharts": "^2.15.3",
     "styled-components": "^5.3.11",
-    "styled-normalize": "^8.1.1"
+    "styled-normalize": "^8.1.1",
+    "webpack-node-externals": "^3.0.0"
   },
   "peerDependencies": {
-    "react": "^18.1.0-0",
-    "react-dom": "^18.1.0-0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "styled-components": "^5.3.11",
     "styled-normalize": "^8.1.1"
   },

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -6,6 +6,11 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+#### 2.0.7
+
+- Update React & React Dom from 18.13.1 to 19.1.0
+- Delete Prop types package no longer supported either used.
+
 #### 2.0.6
 
 - Major package updated eslint-plugin-cypress


### PR DESCRIPTION
This pull request updates the `@commerce7/admin-ui` package to version `2.0.7` and includes changes to dependencies and documentation. The most notable updates are the upgrade of React and React DOM to version `19.1.0`, the removal of the `prop-types` package, and the addition of release notes for version `2.0.7`.

### Dependency Updates:
* Upgraded `react` and `react-dom` dependencies from version `18.3.1` to `19.1.0`.
* Removed `prop-types` package, which is no longer supported or used.

### Package Version Update:
* Updated the package version in `package.json` from `2.0.6` to `2.0.7`.

### Documentation:
* Added release notes for version `2.0.7` in `src/stories/Releases.mdx`, detailing the React and React DOM upgrade and the removal of the `prop-types` package.

### Breaking changes

https://react.dev/blog/2024/04/25/react-19-upgrade-guide#breaking-changes