### PR TITLE
SC-22407 | FEAT-Add-new-vivid-icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "2.0.41",
+  "version": "2.0.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "2.0.41",
+      "version": "2.0.42",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "2.0.41",
+  "version": "2.0.42",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+### 2.0.42
+
+- Add a new yellow color variant to the VividIcon
+
 ### 2.0.41
 
 - Minor NPM packages.

--- a/src/vividIcon/VividIcon.stories.tsx
+++ b/src/vividIcon/VividIcon.stories.tsx
@@ -49,13 +49,14 @@ export const Colors: Story = {
       <VividIcon icon="carrot" color="orange" />
       <VividIcon icon="bag" color="purple" />
       <VividIcon icon="balloon" color="gray" />
+      <VividIcon icon="club" color="yellow" />
     </Container>
   ),
   parameters: {
     docs: {
       description: {
         story:
-          'VividIcon supports seven different colors: pink, blue, green, teal, orange, purple, and gray.'
+          'VividIcon supports eight different colors: pink, blue, green, teal, orange, purple, gray, and yellow.'
       }
     }
   }

--- a/src/vividIcon/VividIcon.styles.tsx
+++ b/src/vividIcon/VividIcon.styles.tsx
@@ -18,7 +18,15 @@ const StyledIconContainer = styled.div`
 `;
 
 interface StyledIconProps {
-  color: 'pink' | 'blue' | 'green' | 'teal' | 'orange' | 'purple' | 'gray';
+  color:
+    | 'pink'
+    | 'blue'
+    | 'green'
+    | 'teal'
+    | 'orange'
+    | 'purple'
+    | 'gray'
+    | 'yellow';
 }
 
 const StyledIcon = styled(Icon)<StyledIconProps>`

--- a/src/vividIcon/VividIcon.tsx
+++ b/src/vividIcon/VividIcon.tsx
@@ -11,6 +11,7 @@ type VividIconColor =
   | 'teal'
   | 'orange'
   | 'purple'
+  | 'yellow'
   | 'gray';
 
 export interface VividIconProps {

--- a/src/vividIcon/theme.js
+++ b/src/vividIcon/theme.js
@@ -29,6 +29,10 @@ const colors = {
     gray: {
       backgroundColor: c7Colors.gray100,
       fillColor: c7Colors.gray600
+    },
+    yellow: {
+      backgroundColor: c7Colors.yellow100,
+      fillColor: c7Colors.yellow300
     }
   },
   dark: {
@@ -58,6 +62,10 @@ const colors = {
     },
     gray: {
       backgroundColor: c7Colors.gray600,
+      fillColor: c7Colors.white
+    },
+    yellow: {
+      backgroundColor: c7Colors.yellow300,
       fillColor: c7Colors.white
     }
   }


### PR DESCRIPTION
## Overview
We want to add a yellow variant to the vivid icon

## Changes
Adds icon variant
Adds theme
Updates stories and package

## Testing

> Risk Level: Low
<img width="1834" height="944" alt="image" src="https://github.com/user-attachments/assets/4c4e2f56-416f-4429-b799-d00b89a36799" />
<img width="1602" height="208" alt="image" src="https://github.com/user-attachments/assets/6cb76063-8508-4cf0-a93c-739e76c9b75a" />

