### PR TITLE
SC-23625 | FEAT - Add Type Declaration Files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "2.0.46",
+  "version": "2.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "2.0.46",
+      "version": "2.0.47",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "npm run build:js && npm run build:types",
     "build:js": "webpack",
-    "build:types": "tsc -p tsconfig.build.json",
+    "build:types": "rm -rf lib/types && tsc -p tsconfig.build.json",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "pre-commit": "lint-staged",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "2.0.46",
+  "version": "2.0.47",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"
   ],
   "main": "./lib/build.js",
+  "types": "./lib/types/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "webpack",
+    "build": "npm run build:js && npm run build:types",
+    "build:js": "webpack",
+    "build:types": "tsc -p tsconfig.build.json",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "pre-commit": "lint-staged",

--- a/src/alert/index.tsx
+++ b/src/alert/index.tsx
@@ -1,5 +1,5 @@
-import Alert, { AlertProps } from './Alert';
+import Alert, { AlertProps, AlertVariant } from './Alert';
 
-export type { AlertProps };
+export type { AlertProps, AlertVariant };
 
 export default Alert;

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -7,11 +7,11 @@ import {
   StyledButtonIcon
 } from './Button.styles';
 
-type ButtonSize = 'default' | 'small';
+export type ButtonSize = 'default' | 'small';
 export type ButtonVariant = 'primary' | 'secondary' | 'text' | 'link';
-type ButtonType = 'button' | 'submit';
+export type ButtonType = 'button' | 'submit';
 
-interface ButtonProps {
+export interface ButtonProps {
   /**
    * The content of the component.
    */

--- a/src/button/index.js
+++ b/src/button/index.js
@@ -1,3 +1,0 @@
-import Button from './Button';
-
-export default Button;

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -1,0 +1,5 @@
+import Button, { ButtonProps, ButtonSize, ButtonVariant } from './Button';
+
+export type { ButtonProps, ButtonSize, ButtonVariant };
+
+export default Button;

--- a/src/buttonMenu/index.tsx
+++ b/src/buttonMenu/index.tsx
@@ -1,7 +1,11 @@
-import ButtonMenuComponent, { ButtonMenuProps } from './ButtonMenu';
+import ButtonMenuComponent, {
+  ButtonMenuProps,
+  ButtonSize,
+  ButtonVariant
+} from './ButtonMenu';
 import ButtonMenuItem, { ButtonMenuItemProps } from './ButtonMenuItem';
 
 const ButtonMenu = Object.assign(ButtonMenuComponent, { ButtonMenuItem });
 
-export type { ButtonMenuProps, ButtonMenuItemProps };
+export type { ButtonMenuProps, ButtonMenuItemProps, ButtonSize, ButtonVariant };
 export default ButtonMenu;

--- a/src/checkboxGroup/CheckboxGroup.tsx
+++ b/src/checkboxGroup/CheckboxGroup.tsx
@@ -8,10 +8,10 @@ import {
   StyledFieldsetLabel
 } from '../common/form/styles';
 
-type CheckboxGroupVariant = 'button' | null;
-type CheckboxGroupSize = 'small' | 'medium' | 'large';
+export type CheckboxGroupVariant = 'button' | null;
+export type CheckboxGroupSize = 'small' | 'medium' | 'large';
 
-interface CheckboxGroupProps {
+export interface CheckboxGroupProps {
   /**
    * The content of the component.
    */

--- a/src/checkboxGroup/index.js
+++ b/src/checkboxGroup/index.js
@@ -1,3 +1,0 @@
-import CheckboxGroup from './CheckboxGroup';
-
-export default CheckboxGroup;

--- a/src/checkboxGroup/index.tsx
+++ b/src/checkboxGroup/index.tsx
@@ -1,0 +1,9 @@
+import CheckboxGroup, {
+  CheckboxGroupProps,
+  CheckboxGroupSize,
+  CheckboxGroupVariant
+} from './CheckboxGroup';
+
+export type { CheckboxGroupProps, CheckboxGroupSize, CheckboxGroupVariant };
+
+export default CheckboxGroup;

--- a/src/common/form/styles.tsx
+++ b/src/common/form/styles.tsx
@@ -20,7 +20,7 @@ const StyledInputWrapper = styled.div.attrs({
   ${({ isButtonVariant }) => (isButtonVariant ? 'margin-bottom: 0px;' : '')}
 `;
 
-interface StyledFormItemProps {
+export interface StyledFormItemProps {
   hasErrorMessage?: boolean;
 }
 

--- a/src/datePicker/DatePicker.tsx
+++ b/src/datePicker/DatePicker.tsx
@@ -159,19 +159,19 @@ const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
           allowClear={allowClear}
           autoFocus={autoFocus}
           className={className}
-          description={description}
+          description={description ?? undefined}
           value={value}
           onChange={onChange as (date: string) => void}
           onFocus={onFocus}
           onBlur={onBlur}
-          label={label}
+          label={label ?? undefined}
           id={id}
           isValidDate={isValidDate}
           disabled={disabled}
           placeholder={placeholder}
           required={required}
-          errorMessage={errorMessage}
-          dataTestId={dataTestId}
+          errorMessage={errorMessage ?? undefined}
+          dataTestId={dataTestId ?? undefined}
           inline={inline}
         />
       );

--- a/src/datePicker/index.tsx
+++ b/src/datePicker/index.tsx
@@ -1,5 +1,6 @@
 import DatePicker, { DatePickerProps } from './DatePicker';
+import { DayDatePickerProps } from './DayDatePicker';
 
-export type { DatePickerProps };
+export type { DatePickerProps, DayDatePickerProps };
 
 export default DatePicker;

--- a/src/displayIcon/index.tsx
+++ b/src/displayIcon/index.tsx
@@ -1,5 +1,8 @@
-import DisplayIcon, { DisplayIconProps } from './DisplayIcon';
+import DisplayIcon, {
+  DisplayIconProps,
+  DisplayIconVariant
+} from './DisplayIcon';
 
-export type { DisplayIconProps };
+export type { DisplayIconProps, DisplayIconVariant };
 
 export default DisplayIcon;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -89,3 +89,73 @@ export {
   Text,
   Tabs
 };
+
+export type { AlertProps, AlertVariant } from './alert';
+export type { AvatarProps } from './avatar';
+export type { BreadcrumbProps, BreadcrumbsProps } from './breadcrumbs';
+export type { ButtonProps, ButtonSize, ButtonVariant } from './button';
+export type {
+  ButtonMenuProps,
+  ButtonMenuItemProps,
+  ButtonSize as ButtonMenuSize,
+  ButtonVariant as ButtonMenuVariant
+} from './buttonMenu';
+export type { CardProps } from './card';
+export type { CardLinkProps } from './cardLink';
+export type { CheckboxProps } from './checkbox';
+export type {
+  CheckboxGroupProps,
+  CheckboxGroupSize,
+  CheckboxGroupVariant
+} from './checkboxGroup';
+export type { ColumnProps, ColumnsProps } from './columns';
+export type {
+  ContextMenuItemProps,
+  ContextMenuMoreActionsProps,
+  ContextMenuProps
+} from './contextMenu';
+export type { DataDisplayProps } from './dataDisplay';
+export type { DatePickerProps, DayDatePickerProps } from './datePicker';
+export type { DisplayIconProps, DisplayIconVariant } from './displayIcon';
+export type { HeadingProps } from './heading';
+export type { IconProps } from './icon';
+export type { InfoCardGridProps, InfoCardProps } from './infoCard';
+export type { InputProps } from './input';
+export type { LegendItem, LegendProps } from './legend';
+export type { LineBreakProps } from './lineBreak';
+export type { LinkButtonProps } from './linkButton';
+export type { ModalBodyProps, ModalFooterProps, ModalProps } from './modal';
+export type {
+  NavLinkProps,
+  NavProps,
+  SubNavLinkProps,
+  SubNavProps
+} from './nav';
+export type { NoRecordsProps } from './noRecords';
+export type { PictureProps } from './picture';
+export type { PieChartProps } from './pieChart';
+export type { ProgressBarProps } from './progressBar';
+export type { RadioProps } from './radio';
+export type { RadioGroupProps } from './radioGroup';
+export type { RegionProps } from './region';
+export type { SelectProps } from './select';
+export type { SelectButtonProps } from './selectButton';
+export type { SpinnerProps } from './spinner';
+export type { StepProps, StepperProps } from './stepper';
+export type { SubMenuItemProps, SubMenuProps } from './subMenu';
+export type { SwitchProps } from './switchComponent';
+export type {
+  TableProps,
+  TbodyProps,
+  TdProps,
+  TfootProps,
+  TheadProps,
+  ThProps,
+  TrProps
+} from './table';
+export type { TabBodyProps, TabProps, TabsProps } from './tabs';
+export type { TagProps, TagVariant } from './tag';
+export type { TextProps } from './text';
+export type { TextareaProps } from './textarea';
+export type { Commerce7AdminUIProps, Theme } from './ui';
+export type { VividIconProps } from './vividIcon';

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+### 2.0.47
+
+- Adds types declaration files
+
 ### 2.0.46
 
 - Minor NPM packages.

--- a/src/tag/index.tsx
+++ b/src/tag/index.tsx
@@ -1,5 +1,5 @@
-import Tag, { TagProps } from './Tag';
+import Tag, { TagProps, TagVariant } from './Tag';
 
-export type { TagProps };
+export type { TagProps, TagVariant };
 
 export default Tag;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": false,
+    "rootDir": "./src",
+    "outDir": "./lib/types"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "**/*.stories.ts", "**/*.stories.tsx"]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -9,5 +9,5 @@
     "outDir": "./lib/types"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "**/*.stories.ts", "**/*.stories.tsx"]
+  "exclude": ["node_modules", "src/stories/**/*", "**/*.stories.ts", "**/*.stories.tsx"]
 }


### PR DESCRIPTION
## Overview
This pull request updates the build process to generate TypeScript type declaration files and exposes them in the package.

## Changes
* Added a new `tsconfig.build.json` configuration to generate type declaration files into `lib/types` during the build.
* Updated the `build` script in `package.json` to generate both JavaScript and type declarations, and added a `types` field to point to the generated declarations.
* Updated the `DatePicker` component to explicitly pass `undefined` for optional props if not provided
* Exported the `StyledFormItemProps` interface from `styles.tsx` for better type reuse.
* Added release notes for version `2.0.47`

## Testing
> Risk Level: Low

