### PR TITLE
SC-23935 | BUG - Modalbody default to auto overflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "2.0.49",
+  "version": "2.0.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce7/admin-ui",
-      "version": "2.0.49",
+      "version": "2.0.50",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce7/admin-ui",
-  "version": "2.0.49",
+  "version": "2.0.50",
   "description": "Commerce7 Admin UI Component Library",
   "keywords": [
     "Commerce7"

--- a/src/modal/ModalBody.styles.tsx
+++ b/src/modal/ModalBody.styles.tsx
@@ -9,7 +9,7 @@ const StyledModalBody = styled.div.withConfig({
 })<{ overflow?: string }>`
   padding: 15px;
   max-height: 65vh;
-  overflow: ${({ overflow }) => overflow || 'visible'};
+  overflow: ${({ overflow }) => overflow || 'auto'};
 
   color: ${({ theme }) => theme.c7__ui.fontColor};
   font-weight: ${({ theme }) => theme.c7__ui.fontWeightBase};

--- a/src/modal/ModalBody.tsx
+++ b/src/modal/ModalBody.tsx
@@ -22,7 +22,7 @@ export interface ModalBodyProps {
 const ModalBody = ({
   children,
   className = '',
-  overflow = 'visible'
+  overflow = 'auto'
 }: ModalBodyProps) => (
   <StyledModalBody className={className} overflow={overflow}>
     {children}

--- a/src/modal/ModalBody.tsx
+++ b/src/modal/ModalBody.tsx
@@ -14,7 +14,7 @@ export interface ModalBodyProps {
   className?: string;
 
   /**
-   * Set the overflow behavior. Defaults to 'visible'.
+   * Set the overflow behavior. Defaults to 'auto'.
    */
   overflow?: 'visible' | 'auto' | 'hidden' | 'scroll';
 }

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -8,7 +8,7 @@ import { Meta } from '@storybook/blocks';
 
 ### 2.0.50
 
-- Defaulted the `ModalBody` overflow back to "auto". 
+- Defaulted the `ModalBody` overflow back to "auto".
 
 ### 2.0.49
 

--- a/src/stories/Releases.mdx
+++ b/src/stories/Releases.mdx
@@ -6,6 +6,10 @@ import { Meta } from '@storybook/blocks';
 
 # Release Notes
 
+### 2.0.50
+
+- Defaulted the `ModalBody` overflow back to "auto". 
+
 ### 2.0.49
 
 - Defaulted the `ModalBody` overflow to "visible" to prevent clipping (e.g., date selector popovers) inside modals.


### PR DESCRIPTION
## Overview
we want to modalbody to overflow to auto so we dont break modals that have extreme heights that need a scrollbar.

## Changes
- changed `ModalBody` default prop to 'auto'